### PR TITLE
extend MQTT Topic

### DIFF
--- a/_P210_MQTTImport.ino
+++ b/_P210_MQTTImport.ino
@@ -75,7 +75,7 @@ boolean Plugin_210(byte function, struct EventStruct *event, String& string)
         {
           string += F("<TR><TD>MQTT Topic ");
           string += varNr + 1;
-          string += F(":<TD><input type='text' size='40' maxlength='40' name='Plugin_210_template");
+          string += F(":<TD><input type='text' size='80' maxlength='80' name='Plugin_210_template");
           string += varNr + 1;
           string += F("' value='");
           string += deviceTemplate[varNr];


### PR DESCRIPTION
I use MQTT for my Home Assistant setup and I am very happy with it. Now I figured out that the max length is just 40 which is not enough as I need more for my different topics. Is it with this Pull request possible having a longer Topic? I Use the binariy and the flashtool and dunno how I would change the topic size to 80