### PR TITLE
Fix MQTT publishing of BME680 Gas value

### DIFF
--- a/_P119_BME680.ino
+++ b/_P119_BME680.ino
@@ -54,7 +54,7 @@ boolean Plugin_119(byte function, struct EventStruct *event, String& string)
       {
         Device[++deviceCount].Number = PLUGIN_ID_119;
         Device[deviceCount].Type = DEVICE_TYPE_I2C;
-        Device[deviceCount].VType = SENSOR_TYPE_TEMP_HUM_BARO;
+        Device[deviceCount].VType = SENSOR_TYPE_QUAD;
         Device[deviceCount].Ports = 0;
         Device[deviceCount].PullUpOption = false;
         Device[deviceCount].InverseLogicOption = false;


### PR DESCRIPTION
The BME680 sensor publishes 4 values - Temperature, Humidity, Pressure, and Gas Resistance. Unfortunately, the OpenHAB MQTT controller only publishes the first 3 values to MQTT. This pull request changes the VType to SENSOR_TYPE_QUAD which resolves the issue.