### PR TITLE
Update _P129_RC522_RFID.ino

### DIFF
--- a/_P129_RC522_RFID.ino
+++ b/_P129_RC522_RFID.ino
@@ -52,7 +52,13 @@ boolean Plugin_129(byte function, struct EventStruct *event, String& string)
         strcpy_P(ExtraTaskSettings.TaskDeviceValueNames[0], PSTR(PLUGIN_VALUENAME1_129));
         break;
       }
-
+      
+      case PLUGIN_GET_DEVICEGPIONAMES:                //define 'GPIO 1st' name in webserver
+      {
+        event->String1 = formatGpioName_output(F("CS PIN"));
+        break;
+      }
+      
     case PLUGIN_WEBFORM_LOAD:
       {
       	// cant compile addFormPinSelect(string, F("Reset Pin"), F("taskdevicepin3"), Settings.TaskDevicePin3[event->TaskIndex]);

--- a/_P129_RC522_RFID.ino
+++ b/_P129_RC522_RFID.ino
@@ -7,7 +7,7 @@
 #define PLUGIN_ID_129         129
 #define PLUGIN_NAME_129       "RFID - RC522 SPI"
 #define PLUGIN_VALUENAME1_129 "Tag"
-#define PLUGIN_129_CS         16
+// #define PLUGIN_129_CS         16      //needed?
 
 #include <SPI.h>
 #include <MFRC522.h>
@@ -55,7 +55,8 @@ boolean Plugin_129(byte function, struct EventStruct *event, String& string)
 
     case PLUGIN_WEBFORM_LOAD:
       {
-      	addFormPinSelect(string, F("Reset Pin"), F("taskdevicepin3"), Settings.TaskDevicePin3[event->TaskIndex]);
+      	// cant compile addFormPinSelect(string, F("Reset Pin"), F("taskdevicepin3"), Settings.TaskDevicePin3[event->TaskIndex]);
+        addFormPinSelect(F("Reset Pin"), F("taskdevicepin3"), Settings.TaskDevicePin3[event->TaskIndex]);
         success = true;
         break;
       }
@@ -86,7 +87,8 @@ boolean Plugin_129(byte function, struct EventStruct *event, String& string)
           counter = 0;
           uint8_t uid[] = { 0, 0, 0, 0, 0, 0, 0 };
           uint8_t uidLength;
-          byte error = Plugin_129_readPassiveTargetID(PN532_MIFARE_ISO14443A, uid, &uidLength);
+          // byte error = Plugin_129_readPassiveTargetID(PN532_MIFARE_ISO14443A, uid, &uidLength);
+          byte error = Plugin_129_readPassiveTargetID(uid, &uidLength);  // not defined if plugin P017_PN532 is not selected!
 
           if (error == 1)
           {
@@ -192,7 +194,8 @@ boolean Plugin_129_Init(int8_t csPin, int8_t resetPin)
 /*********************************************************************************************\
  * RC522 read tag ID
 \*********************************************************************************************/
-byte Plugin_129_readPassiveTargetID(uint8_t cardbaudrate, uint8_t *uid, uint8_t *uidLength)
+//byte Plugin_129_readPassiveTargetID(uint8_t cardbaudrate, uint8_t *uid, uint8_t *uidLength)
+byte Plugin_129_readPassiveTargetID(uint8_t *uid, uint8_t *uidLength)  //needed ? see above (not PN532)
 {
   // Getting ready for Reading PICCs
   if ( ! mfrc522.PICC_IsNewCardPresent()) { //If a new PICC placed to RFID reader continue


### PR DESCRIPTION
Thanks for plugin! modified otherwise compile errors with arduino 1.8.10 (only this plugin enabled)
I'm using wemos D1 ,init works (get SW V2.0) but cards are not detected. 

added 'case PLUGIN_GET_DEVICEGPIONAMES:' to show GPIO name in webserver
i had to comment lines for PerformSelfTest (165-194) otherwise tag read does not work.
-> So plugin works for me (ESPEasy-mega-20191208, Arduino 1.8.10, wemos D1 mini Pro, default SPI and D8-SDA(CS) and D3-RST)