### PR TITLE
Add support for AHT10/20/21 temperature/humidity device

### DIFF
--- a/_P248_AHT.ino
+++ b/_P248_AHT.ino
@@ -1,0 +1,151 @@
+#include "_Plugin_Helper.h"
+#ifdef USES_P248
+
+// #######################################################################################################
+// ######################## Plugin 248 AHT I2C Temperature and Humidity Sensor  ##########################
+// #######################################################################################################
+// data sheet AHT10: https://wiki.liutyi.info/display/ARDUINO/AHT10
+// device AHT10: http://www.aosong.com/en/products-40.html
+// device and manual AHT20: http://www.aosong.com/en/products-32.html
+// device and manual AHT21: http://www.aosong.com/en/products-60.html
+
+#include "src/PluginStructs/P248_data_struct.h"
+
+#define PLUGIN_248
+#define PLUGIN_ID_248         248
+#define PLUGIN_NAME_248       "Environment - AHT10/20/21 [TESTING]"
+#define PLUGIN_VALUENAME1_248 "Temperature"
+#define PLUGIN_VALUENAME2_248 "Humidity"
+
+
+boolean Plugin_248(byte function, struct EventStruct *event, String& string)
+{
+  boolean success = false;
+
+  switch (function)
+  {
+    case PLUGIN_DEVICE_ADD:
+    {
+      Device[++deviceCount].Number           = PLUGIN_ID_248;
+      Device[deviceCount].Type               = DEVICE_TYPE_I2C;
+      Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_TEMP_HUM;
+      Device[deviceCount].Ports              = 0;
+      Device[deviceCount].PullUpOption       = false;
+      Device[deviceCount].InverseLogicOption = false;
+      Device[deviceCount].FormulaOption      = true;
+      Device[deviceCount].ValueCount         = 2;
+      Device[deviceCount].SendDataOption     = true;
+      Device[deviceCount].TimerOption        = true;
+      Device[deviceCount].GlobalSyncOption   = true;
+      break;
+    }
+
+    case PLUGIN_GET_DEVICENAME:
+    {
+      string = F(PLUGIN_NAME_248);
+      break;
+    }
+
+    case PLUGIN_GET_DEVICEVALUENAMES:
+    {
+      strcpy_P(ExtraTaskSettings.TaskDeviceValueNames[0], PSTR(PLUGIN_VALUENAME1_248));
+      strcpy_P(ExtraTaskSettings.TaskDeviceValueNames[1], PSTR(PLUGIN_VALUENAME2_248));
+      break;
+    }
+
+    case PLUGIN_INIT:
+    {
+      initPluginTaskData(event->TaskIndex,
+        new (std::nothrow) P248_data_struct(PCONFIG(0), (AHTx_device_type)PCONFIG(1)));
+      P248_data_struct *P248_data =
+        static_cast<P248_data_struct *>(getPluginTaskData(event->TaskIndex));
+
+      if (nullptr == P248_data) {
+        return success;
+      }
+      success = true;
+
+      break;
+    }
+
+    case PLUGIN_WEBFORM_SHOW_I2C_PARAMS:
+    {
+      int Plugin_28_i2c_addresses[2] = { 0x38, 0x39 };
+      addFormSelectorI2C(F("i2c_addr"), 2, Plugin_28_i2c_addresses, PCONFIG(0));
+      break;
+    }
+
+    case PLUGIN_WEBFORM_LOAD:
+    {
+      addFormNote(F("SDO Low=0x38, High=0x39"));
+
+      const String options[] = { F("AHT10"), F("AHT20"), F("AHT21") };
+      int indices[] = { AHT10_DEVICE, AHT20_DEVICE, AHT21_DEVICE };
+      addFormSelector(F("Sensor model"), F("p248_ahttype"), 3, options, indices, PCONFIG(1));
+
+      success = true;
+      break;
+    }
+
+    case PLUGIN_WEBFORM_SAVE:
+    {
+      PCONFIG(0) = getFormItemInt(F("i2c_addr"));
+      PCONFIG(1) = getFormItemInt(F("p248_ahttype"));
+      success    = true;
+      break;
+    }
+    case PLUGIN_ONCE_A_SECOND:
+    {
+      P248_data_struct *P248_data =
+        static_cast<P248_data_struct *>(getPluginTaskData(event->TaskIndex));
+
+      if (nullptr != P248_data) {
+        if (P248_data->updateMeasurements(event->TaskIndex)) {
+          // Update was succesfull, schedule a read.
+          Scheduler.schedule_task_device_timer(event->TaskIndex, millis() + 10);
+        }
+      }
+      break;
+    }
+
+    case PLUGIN_READ:
+    {
+      P248_data_struct *P248_data =
+        static_cast<P248_data_struct *>(getPluginTaskData(event->TaskIndex));
+
+      if (nullptr != P248_data) {
+        if (P248_data->state != AHTx_New_values) {
+          success = false;
+          break;
+        }
+        P248_data->state = AHTx_Values_read;
+
+        UserVar[event->BaseVarIndex]     = P248_data->getTemperature();
+        UserVar[event->BaseVarIndex + 1] = P248_data->getHumidity();
+
+        if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+          String log;
+          log.reserve(40); // Prevent re-allocation
+          log  = P248_data->getDeviceName();
+          log += F(" : Address: 0x");
+          log += String(PCONFIG(0), HEX);
+          addLog(LOG_LEVEL_INFO, log);
+          log  = P248_data->getDeviceName();
+          log += F(" : Temperature: ");
+          log += formatUserVarNoCheck(event->TaskIndex, 0);
+          addLog(LOG_LEVEL_INFO, log);
+
+          log  = P248_data->getDeviceName();
+          log += F(" : Humidity: ");
+          log += formatUserVarNoCheck(event->TaskIndex, 1);
+          addLog(LOG_LEVEL_INFO, log);
+        }
+        success = true;
+      }
+      break;
+    }
+  }
+  return success;
+}
+
+#endif // USES_P248

--- a/src/PluginStructs/P248_data_struct.cpp
+++ b/src/PluginStructs/P248_data_struct.cpp
@@ -1,0 +1,170 @@
+#include "../PluginStructs/P248_data_struct.h"
+
+#ifdef USES_P248
+
+# include "../Helpers/Convert.h"
+
+struct AHTx_Status {
+  inline AHTx_Status(uint8_t stat) : status(stat) {}
+
+  inline bool valid() const { return status != 0xFF; }
+
+  inline bool calibrated() const { return (status & (1 << 3)) != 0; }
+
+  inline bool busy() const { return (status & (1 << 7)) != 0; }
+
+  const uint8_t status;
+};
+
+AHTx_Device::AHTx_Device(uint8_t addr, AHTx_device_type type) :
+  i2cAddress(addr),
+  device_type(type),
+  last_hum_val(0),
+  last_temp_val(0) {}
+
+String AHTx_Device::getDeviceName() const {
+  switch(device_type) {
+    case AHT10_DEVICE: return F("AHT10");
+    case AHT20_DEVICE: return F("AHT20");
+    case AHT21_DEVICE: return F("AHT21");
+    default: return F("AHTx");
+  }
+}
+
+bool AHTx_Device::initialize() {
+  const uint8_t cmd_init = (device_type == AHT10_DEVICE) ? 0xE1 : 0xBE;
+  return I2C_write16_reg(i2cAddress, cmd_init, 0x0800);
+}
+
+bool AHTx_Device::triggerMeasurement() {
+  return I2C_write16_reg(i2cAddress, 0xAC, 0x3300); // measurement time takes over 80 msec
+}
+
+bool AHTx_Device::softReset() {
+  return I2C_write8(i2cAddress, 0xBA); // soft reset takes less than 20 msec
+}
+
+uint8_t AHTx_Device::readStatus() {
+  return I2C_read8(i2cAddress, NULL);
+}
+
+bool AHTx_Device::readData() {
+  const uint8_t data_len = 6;
+
+  // I2C_read8 len
+  if (Wire.requestFrom(i2cAddress, data_len) == 0) {
+    return false;
+  }
+
+  uint8_t data[data_len];
+  for (uint8_t i = 0; i < data_len; ++i) {
+    data[i] = Wire.read();
+  }
+
+  // check status
+  AHTx_Status status = data[0];
+  if (not (status.valid() and status.calibrated())) {
+    return false;
+  }
+
+  // 20 bits humidity value
+  uint32_t value = data[1];
+  value = (value << 8) | data[2];
+  value = (value << 4) | (data[3] >> 4);
+  last_hum_val = (float)value / (1 << 20) * 100;
+
+  // 20 bits temperature value
+  value = data[3] & 0x0F;
+  value = (value << 8) | data[4];
+  value = (value << 8) | data[5];
+  last_temp_val = (float)value / (1 << 20) * 200 - 50;
+
+  return true;
+}
+
+P248_data_struct::P248_data_struct(uint8_t addr, AHTx_device_type dev) :
+  device(addr, dev),
+  state(AHTx_Uninitialized),
+  last_measurement(0),
+  trigger_time(0) {}
+
+bool P248_data_struct::initialized() const {
+  return state != AHTx_Uninitialized;
+}
+
+void P248_data_struct::setUninitialized() {
+  state = AHTx_Uninitialized;
+}
+
+// Perform the measurements with interval
+bool P248_data_struct::updateMeasurements(unsigned long task_index) {
+  const unsigned long current_time = millis();
+
+  if (!initialized()) {
+    if (!device.initialize()) {
+      addLog(LOG_LEVEL_DEBUG, getDeviceName() + F(" : unable to initialize"));
+      return false;
+    }
+    addLog(LOG_LEVEL_INFO, getDeviceName() + F(" : initialized"));
+
+    trigger_time = current_time;
+    state = AHTx_Trigger_measurement;
+    return false;
+  }
+
+  if (state != AHTx_Wait_for_samples and state != AHTx_Trigger_measurement) {
+    if (!timeOutReached(last_measurement + (Settings.TaskDeviceTimer[task_index] * 1000))) {
+      // Timeout has not yet been reached.
+      return false;
+    }
+    trigger_time = current_time;
+    state = AHTx_Trigger_measurement;
+  }
+
+  // state: AHTx_Wait_for_samples or AHTx_Trigger_measurement
+  AHTx_Status status = device.readStatus();
+  if (status.valid() and status.calibrated() and not status.busy()) {
+
+    if (state == AHTx_Trigger_measurement) {
+      device.triggerMeasurement();
+
+      trigger_time = current_time;
+      state = AHTx_Wait_for_samples;
+      return false;
+    }
+
+    // state: AHTx_Wait_for_samples
+    if (!device.readData()) {
+      return false;
+    }
+
+    last_measurement = current_time;
+    state = AHTx_New_values;
+
+    if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+      String log;
+      log.reserve(120); // Prevent re-allocation
+      log  = getDeviceName();
+      log += F(" : humidity ");
+      log += device.getHumidity();
+      log += F("% temperature ");
+      log += device.getTemperature();
+      log += F("C");
+      addLog(LOG_LEVEL_INFO, log);
+    }
+
+    return true;
+  }
+
+  if (timePassedSince(trigger_time) > 1000) {
+    // should not happen
+    addLog(LOG_LEVEL_ERROR, getDeviceName() + F(" : reset"));
+    device.softReset();
+
+    state = AHTx_Uninitialized;
+  }
+
+  return false;
+}
+
+#endif // ifdef USES_P248

--- a/src/PluginStructs/P248_data_struct.h
+++ b/src/PluginStructs/P248_data_struct.h
@@ -1,0 +1,65 @@
+#ifndef PLUGINSTRUCTS_P248_DATA_STRUCT_H
+#define PLUGINSTRUCTS_P248_DATA_STRUCT_H
+
+#include "../../_Plugin_Helper.h"
+#ifdef USES_P248
+
+enum AHTx_device_type {
+  AHT10_DEVICE = 10,
+  AHT20_DEVICE = 20,
+  AHT21_DEVICE = 21,
+};
+
+enum AHTx_state {
+  AHTx_Uninitialized = 0,
+  AHTx_Initialized,
+  AHTx_Trigger_measurement,
+  AHTx_Wait_for_samples,
+  AHTx_New_values,
+  AHTx_Values_read
+};
+
+class AHTx_Device {
+public:
+  AHTx_Device(uint8_t addr, AHTx_device_type type);
+
+  String getDeviceName() const;
+  inline float getHumidity() const { return last_hum_val; }
+  inline float getTemperature() const { return last_temp_val; }
+
+  bool initialize();
+  bool triggerMeasurement();
+  bool softReset();
+  uint8_t readStatus();
+  bool readData();
+
+protected:
+  const uint8_t i2cAddress;
+  const AHTx_device_type device_type;
+  float last_hum_val;
+  float last_temp_val;
+};
+
+struct P248_data_struct : public PluginTaskData_base {
+  P248_data_struct(uint8_t addr, AHTx_device_type dev);
+
+  inline String getDeviceName() const { return device.getDeviceName(); }
+  inline float getHumidity() const { return device.getHumidity(); }
+  inline float getTemperature() const { return device.getTemperature(); }
+
+  bool initialized() const;
+
+  void setUninitialized();
+
+  // Perform the measurements with interval
+  bool updateMeasurements(unsigned long task_index);
+
+  AHTx_Device device;
+  AHTx_state state;
+  unsigned long last_measurement;
+  unsigned long trigger_time;
+};
+
+#endif // ifdef USES_P248
+
+#endif // PLUGINSTRUCTS_P248_DATA_STRUCT_H


### PR DESCRIPTION
Added support for the AHT10, AHT20 and AHT21 sensor.

Used the P028_BME280 implementation as template to create this plugin.
Tested with ESP8266 and ESP32 using the AHT10 sensor only (AHT20 and AHT21 untested).

Additional modifications in the I2C-scanner to add detection for this sensor:
`/src/WebServer/I2C_Scanner.cpp`
`     case 0x38:`
`+      result =  F("PCF8574A,AHT10/20/21");`
`+      break;`
 `    case 0x39:`
`-      result =  F("PCF8574A,TSL2561,APDS9960");`
`+      result =  F("PCF8574A,TSL2561,APDS9960,AHT10");`
