### PR TITLE
Updated Itho library + device ID now programmable

### DIFF
--- a/_P145_Itho.ino
+++ b/_P145_Itho.ino
@@ -11,6 +11,7 @@
 //			receive ISR with Ticker was the cause of instability. Inspired by: https://github.com/arnemauer/Ducobox-ESPEasy-Plugin
 //			svollebregt, 11-04-2020 - Minor changes to make code compatible with latest mega 20200410, removed SYNC1 option for now;
 //			better to change this value in the Itho-lib code and compile it yourself
+//			svollebreggt, 13-2-2021 - Now uses rewirtten library made by arjenhiemstra: https://github.com/arjenhiemstra/IthoEcoFanRFT
 
 // Recommended to disable RF receive logging to minimize code execution within interrupts
 
@@ -62,9 +63,9 @@
 
 //This extra settings struct is needed because the default settingsstruct doesn't support strings
 struct PLUGIN_145_ExtraSettingsStruct
-{	char ID1[24];
-	char ID2[24];
-	char ID3[24];
+{	char ID1[9];
+	char ID2[9];
+	char ID3[9];
 } PLUGIN_145_ExtraSettings;
 
 IthoCC1101 PLUGIN_145_rf;
@@ -84,7 +85,7 @@ bool PLUGIN_145_Log = false;
 
 // volatile for interrupt function
 volatile bool PLUGIN_145_Int = false;
-volatile unsigned long PLUGIN_145_Int_time = 0;
+//volatile unsigned long PLUGIN_145_Int_time = 0;
 
 #define PLUGIN_145
 #define PLUGIN_ID_145         145
@@ -144,7 +145,9 @@ boolean Plugin_145(byte function, struct EventStruct *event, String &string)
 	case PLUGIN_SET_DEFAULTS:
 		{
     	PCONFIG(0) = 1;
-			PCONFIG(1) = 170;
+			PCONFIG(1) = 10;
+			PCONFIG(2) = 87;
+			PCONFIG(3) = 81;
     	success = true;
 			break;
 		}
@@ -159,11 +162,12 @@ boolean Plugin_145(byte function, struct EventStruct *event, String &string)
 			}
 			LoadCustomTaskSettings(event->TaskIndex, (byte*)&PLUGIN_145_ExtraSettings, sizeof(PLUGIN_145_ExtraSettings));
 			addLog(LOG_LEVEL_INFO, F("Extra Settings PLUGIN_145 loaded"));
-			PLUGIN_145_rf.setSync1(PCONFIG(1));
+			//PLUGIN_145_rf.setSync1(PCONFIG(1));
+			PLUGIN_145_rf.setDeviceID(PCONFIG(1), PCONFIG(2), PCONFIG(3)); //DeviceID used to send commands, can also be changed on the fly for multi itho control, 10,87,81 corresponds with old library
 			PLUGIN_145_rf.init();
 			Plugin_145_IRQ_pin = Settings.TaskDevicePin1[event->TaskIndex];
 			pinMode(Plugin_145_IRQ_pin, INPUT);
-			attachInterrupt(Plugin_145_IRQ_pin, PLUGIN_145_ITHOinterrupt, RISING);
+			attachInterrupt(Plugin_145_IRQ_pin, PLUGIN_145_ITHOinterrupt, FALLING);
 			addLog(LOG_LEVEL_INFO, F("CC1101 868Mhz transmitter initialized"));
 			PLUGIN_145_rf.initReceive();
 			PLUGIN_145_InitRunned=true;
@@ -213,7 +217,8 @@ boolean Plugin_145(byte function, struct EventStruct *event, String &string)
 		if (PLUGIN_145_Int)
 		{
 			PLUGIN_145_Int = false; // reset flag
-
+			PLUGIN_145_ITHOcheck();
+			/*
 			unsigned long time_elapsed = millis() - PLUGIN_145_Int_time;
 			if (time_elapsed >= 10)
 			{
@@ -223,7 +228,7 @@ boolean Plugin_145(byte function, struct EventStruct *event, String &string)
 			{
 				delay(10-time_elapsed);
 				PLUGIN_145_ITHOcheck();
-			}
+			}*/
 		}
 		success = true;
 		break;
@@ -378,12 +383,14 @@ boolean Plugin_145(byte function, struct EventStruct *event, String &string)
   case PLUGIN_WEBFORM_LOAD:
   {
 		addFormSubHeader(F("Remote RF Controls"));
-    addFormTextBox(F("Unit ID remote 1"), F("PLUGIN_145_ID1"), PLUGIN_145_ExtraSettings.ID1, 23);
-    addFormTextBox(F("Unit ID remote 2"), F("PLUGIN_145_ID2"), PLUGIN_145_ExtraSettings.ID2, 23);
-    addFormTextBox(F("Unit ID remote 3"), F("PLUGIN_145_ID3"), PLUGIN_145_ExtraSettings.ID3, 23);
+    addFormTextBox(F("Unit ID remote 1"), F("PLUGIN_145_ID1"), PLUGIN_145_ExtraSettings.ID1, 8);
+    addFormTextBox(F("Unit ID remote 2"), F("PLUGIN_145_ID2"), PLUGIN_145_ExtraSettings.ID2, 8);
+    addFormTextBox(F("Unit ID remote 3"), F("PLUGIN_145_ID3"), PLUGIN_145_ExtraSettings.ID3, 8);
 		addFormCheckBox(F("Enable RF receive log"), F("p145_log"), PCONFIG(0));
-		addFormNumericBox(F("Remote SYNC1 byte"), F("p145_remote"), PCONFIG(1), 0, 255);
-		addFormNote(F("Sync byte for remote, known good values: 170 (default, remote with timer) and 172 (remote with not-at-home functionality)"));
+		addFormNumericBox(F("Device ID byte 1"), F("p145_deviceid1"), PCONFIG(1), 0, 255);
+		addFormNumericBox(F("Device ID byte 2"), F("p145_deviceid2"), PCONFIG(2), 0, 255);
+		addFormNumericBox(F("Device ID byte 3"), F("p145_deviceid3"), PCONFIG(3), 0, 255);
+		addFormNote(F("Device ID of your ESP, should not be the same as your neighbours ;-). Defaults to 10,87,81 which corresponds to the old Itho code"));
     success = true;
     break;
   }
@@ -397,7 +404,9 @@ boolean Plugin_145(byte function, struct EventStruct *event, String &string)
 
 		PCONFIG(0) = isFormItemChecked(F("p145_log"));
 		PLUGIN_145_Log = PCONFIG(0);
-		PCONFIG(1) = getFormItemInt(F("p145_remote"), 170);
+		PCONFIG(1) = getFormItemInt(F("p145_deviceid1"), 10);
+		PCONFIG(2) = getFormItemInt(F("p145_deviceid2"), 87);
+		PCONFIG(3) = getFormItemInt(F("p145_deviceid3"), 81);
 	  success = true;
     break;
   }
@@ -405,10 +414,10 @@ boolean Plugin_145(byte function, struct EventStruct *event, String &string)
 return success;
 }
 
-void ICACHE_RAM_ATTR PLUGIN_145_ITHOinterrupt()
+ICACHE_RAM_ATTR void PLUGIN_145_ITHOinterrupt()
 {
 	PLUGIN_145_Int = true; //flag
-	PLUGIN_145_Int_time = millis(); //used to register time since interrupt, to make sure we don't read within 10 ms as the RX buffer needs some time to get ready
+	//PLUGIN_145_Int_time = millis(); //used to register time since interrupt, to make sure we don't read within 10 ms as the RX buffer needs some time to get ready
 }
 
 void PLUGIN_145_ITHOcheck()

--- a/libraries _PLUGIN145 ITHO FAN/Itho/CC1101.cpp
+++ b/libraries _PLUGIN145 ITHO FAN/Itho/CC1101.cpp
@@ -30,7 +30,7 @@ inline void CC1101::deselect(void) {
 
 void CC1101::spi_waitMiso()
 {
-    while(digitalRead(MISO) == HIGH) delay(0);
+    while(digitalRead(MISO) == HIGH) yield();
 }
 
 void CC1101::init()
@@ -55,19 +55,19 @@ void CC1101::reset()
 	deselect();
 }
 
-uint8_t CC1101::writeCommand(uint8_t command)
+uint8_t CC1101::writeCommand(uint8_t command) 
 {
 	uint8_t result;
-
+	
 	select();
 	spi_waitMiso();
 	result = SPI.transfer(command);
 	deselect();
-
+	
 	return result;
 }
 
-void CC1101::writeRegister(uint8_t address, uint8_t data)
+void CC1101::writeRegister(uint8_t address, uint8_t data) 
 {
 	select();
 	spi_waitMiso();
@@ -79,13 +79,13 @@ void CC1101::writeRegister(uint8_t address, uint8_t data)
 uint8_t CC1101::readRegister(uint8_t address)
 {
 	uint8_t val;
-
+  
 	select();
 	spi_waitMiso();
 	SPI.transfer(address);
 	val = SPI.transfer(0);
 	deselect();
-
+  
 	return val;
 }
 
@@ -106,29 +106,29 @@ uint8_t CC1101::readRegisterMedian3(uint8_t address)
   if (val3 > val2) {val = val3; val3 = val2; val2 = val; } //Swap(val3,val2)
   if (val2 > val1) {val = val2; val2 = val1, val1 = val; } //Swap(val2,val1)
   if (val3 > val2) {val = val3; val3 = val2, val2 = val; } //Swap(val3,val2)
-
+  
   return val2;
 }
 
 /* Known SPI/26MHz synchronization bug (see CC1101 errata)
-This issue affects the following registers: SPI status byte (fields STATE and FIFO_BYTES_AVAILABLE),
-FREQEST or RSSI while the receiver is active, MARCSTATE at any time other than an IDLE radio state,
+This issue affects the following registers: SPI status byte (fields STATE and FIFO_BYTES_AVAILABLE), 
+FREQEST or RSSI while the receiver is active, MARCSTATE at any time other than an IDLE radio state, 
 RXBYTES when receiving or TXBYTES when transmitting, and WORTIME1/WORTIME0 at any time.*/
 //uint8_t CC1101::readRegisterWithSyncProblem(uint8_t address, uint8_t registerType)
 uint8_t /* ICACHE_RAM_ATTR */ CC1101::readRegisterWithSyncProblem(uint8_t address, uint8_t registerType)
 {
-	uint8_t value1, value2;
-
+	uint8_t value1, value2;	
+	
 	value1 = readRegister(address | registerType);
-
+	
 	//if two consecutive reads gives us the same result then we know we are ok
-	do
+	do 
 	{
 		value2 = value1;
 		value1 = readRegister(address | registerType);
-	}
+	} 
 	while (value1 != value2);
-
+	
 	return value1;
 }
 
@@ -142,9 +142,9 @@ uint8_t CC1101::readRegister(uint8_t address, uint8_t registerType)
 		case CC1101_RXBYTES:
 		case CC1101_TXBYTES:
 		case CC1101_WORTIME1:
-		case CC1101_WORTIME0:
-			return readRegisterWithSyncProblem(address, registerType);
-
+		case CC1101_WORTIME0:	
+			return readRegisterWithSyncProblem(address, registerType);	
+			
 		default:
 			return readRegister(address | registerType);
 	}
@@ -166,15 +166,15 @@ void CC1101::writeBurstRegister(uint8_t address, uint8_t* data, uint8_t length)
 void CC1101::readBurstRegister(uint8_t* buffer, uint8_t address, uint8_t length)
 {
 	uint8_t i;
-
+	
 	select();
 	spi_waitMiso();
 	SPI.transfer(address | CC1101_READ_BURST);
-
+	
 	for (i = 0; i < length; i++) {
 		buffer[i] = SPI.transfer(0x00);
 	}
-
+	
 	deselect();
 }
 
@@ -183,29 +183,32 @@ uint8_t CC1101::receiveData(CC1101Packet* packet, uint8_t length)
 {
 	uint8_t rxBytes = readRegisterWithSyncProblem(CC1101_RXBYTES, CC1101_STATUS_REGISTER);
 	rxBytes = rxBytes & CC1101_BITS_RX_BYTES_IN_FIFO;
-
+	
 	//check for rx fifo overflow
 	if ((readRegisterWithSyncProblem(CC1101_MARCSTATE, CC1101_STATUS_REGISTER) & CC1101_BITS_MARCSTATE) == CC1101_MARCSTATE_RXFIFO_OVERFLOW)
 	{
 		writeCommand(CC1101_SIDLE);	//idle
 		writeCommand(CC1101_SFRX); //flush RX buffer
-		writeCommand(CC1101_SRX); //switch to RX state
+		writeCommand(CC1101_SRX); //switch to RX state	
 	}
 	else if (rxBytes == length)
 	{
 		readBurstRegister(packet->data, CC1101_RXFIFO, rxBytes);
 
 		//continue RX
-		writeCommand(CC1101_SIDLE);	//idle
+		writeCommand(CC1101_SIDLE);	//idle		
 		writeCommand(CC1101_SFRX); //flush RX buffer
-		writeCommand(CC1101_SRX); //switch to RX state
-
-		packet->length = rxBytes;
+		writeCommand(CC1101_SRX); //switch to RX state	
+		
+		packet->length = rxBytes;				
 	}
 	else
 	{
 		//empty fifo
 		packet->length = 0;
+		writeCommand(CC1101_SIDLE); //idle    
+		writeCommand(CC1101_SFRX); //flush RX buffer
+		writeCommand(CC1101_SRX); //switch to RX state     		
 	}
 
 	return packet->length;
@@ -217,56 +220,55 @@ void CC1101::sendData(CC1101Packet *packet)
 	uint8_t index = 0;
 	uint8_t txStatus, MarcState;
 	uint8_t length;
-
+	
 	writeCommand(CC1101_SIDLE);		//idle
 
 	txStatus = readRegisterWithSyncProblem(CC1101_TXBYTES, CC1101_STATUS_REGISTER);
-
+		
 	//clear TX fifo if needed
 	if (txStatus & CC1101_BITS_TX_FIFO_UNDERFLOW)
 	{
 		writeCommand(CC1101_SIDLE);	//idle
 		writeCommand(CC1101_SFTX);	//flush TX buffer
-	}
-
-	writeCommand(CC1101_SIDLE);		//idle
-
+	}	
+	
+	writeCommand(CC1101_SIDLE);		//idle	
+	
 	//determine how many bytes to send
 	length = (packet->length <= CC1101_DATA_LEN ? packet->length : CC1101_DATA_LEN);
-
+	
 	writeBurstRegister(CC1101_TXFIFO, packet->data, length);
 
 	writeCommand(CC1101_SIDLE);
 	//start sending packet
-	writeCommand(CC1101_STX);
+	writeCommand(CC1101_STX);		
 
 	//continue sending when packet is bigger than 64 bytes
 	if (packet->length > CC1101_DATA_LEN)
 	{
 		index += length;
-
+		
 		//loop until all bytes are transmitted
 		while (index < packet->length)
 		{
 			//check if there is free space in the fifo
 			while ((txStatus = (readRegisterMedian3(CC1101_TXBYTES | CC1101_STATUS_REGISTER) & CC1101_BITS_RX_BYTES_IN_FIFO)) > (CC1101_DATA_LEN - 2));
-
+			
 			//calculate how many bytes we can send
 			length = (CC1101_DATA_LEN - txStatus);
 			length = ((packet->length - index) < length ? (packet->length - index) : length);
-
+			
 			//send some more bytes
 			for (int i=0; i<length; i++)
 				writeRegister(CC1101_TXFIFO, packet->data[index+i]);
-
-			index += length;
+			
+			index += length;			
 		}
 	}
 
 	//wait until transmission is finished (TXOFF_MODE is expected to be set to 0/IDLE or TXFIFO_UNDERFLOW)
 	do
 	{
-		delay(0);
 		MarcState = (readRegisterWithSyncProblem(CC1101_MARCSTATE, CC1101_STATUS_REGISTER) & CC1101_BITS_MARCSTATE);
 //		if (MarcState == CC1101_MARCSTATE_TXFIFO_UNDERFLOW) Serial.print(F("TXFIFO_UNDERFLOW occured in sendData() \n"));
 	}

--- a/libraries _PLUGIN145 ITHO FAN/Itho/CC1101Packet.h
+++ b/libraries _PLUGIN145 ITHO FAN/Itho/CC1101Packet.h
@@ -6,9 +6,7 @@
 #define CC1101PACKET_H_
 
 #include <stdio.h>
-#ifdef ESP8266
 #include <Arduino.h>
-#endif
 
 #define CC1101_BUFFER_LEN        64
 #define CC1101_DATA_LEN          CC1101_BUFFER_LEN - 3
@@ -18,7 +16,7 @@ class CC1101Packet
 {
 	public:
 		uint8_t length;
-		uint8_t data[72];
+		uint8_t data[128];
 };
 
 

--- a/libraries _PLUGIN145 ITHO FAN/Itho/IthoCC1101.cpp
+++ b/libraries _PLUGIN145 ITHO FAN/Itho/IthoCC1101.cpp
@@ -1,54 +1,56 @@
 /*
- * Author: Klusjesman, modified bij supersjimmie for Arduino/ESP8266
- */
+   Author: Klusjesman, supersjimmie, modified and reworked by arjenhiemstra
+*/
+#define DEBUG 0
+
+#define BYTE_TO_BINARY_PATTERN "%c,%c,%c,%c,%c,%c,%c,%c,"
+#define BYTE_TO_BINARY(byte)  \
+  (byte & 0x80 ? '1' : '0'), \
+  (byte & 0x40 ? '1' : '0'), \
+  (byte & 0x20 ? '1' : '0'), \
+  (byte & 0x10 ? '1' : '0'), \
+  (byte & 0x08 ? '1' : '0'), \
+  (byte & 0x04 ? '1' : '0'), \
+  (byte & 0x02 ? '1' : '0'), \
+  (byte & 0x01 ? '1' : '0')
 
 #include "IthoCC1101.h"
 #include <string.h>
 #include <Arduino.h>
 #include <SPI.h>
 
+//#define CRC_FILTER
+
+////original sync byte pattern
+//#define STARTBYTE 6 //relevant data starts 6 bytes after the sync pattern bytes 170/171
+//#define SYNC1 170
+//#define SYNC0 171
+//#define MDMCFG2 0x02 //16bit sync word / 16bit specific
+
+////alternative sync byte pattern (filter much more non-itho messages out. Maybe too strict? Testing needed.
+//#define STARTBYTE 0 //relevant data starts 0 bytes after the sync pattern bytes 179/42/171/42
+//#define SYNC1 187 //byte11 = 179, byte13 = 171 with SYNC1 = 163, 179 and 171 differ only by 1 bit
+//#define SYNC0 42
+//#define MDMCFG2 0x03 //32bit sync word / 30bit specific
+
+//alternative sync byte pattern
+#define STARTBYTE 2 //relevant data starts 2 bytes after the sync pattern bytes 179/42
+#define SYNC1 179
+#define SYNC0 42
+#define MDMCFG2 0x02 //16bit sync word / 16bit specific
+
 // default constructor
 IthoCC1101::IthoCC1101(uint8_t counter, uint8_t sendTries) : CC1101()
 {
-	this->outIthoPacket.counter = counter;
-	this->outIthoPacket.previous = IthoLow;
-	this->sendTries = sendTries;
-//	this->receiveState = ExpectNormalCommand;
-	this->receiveState = ExpectMessageStart;
+  this->outIthoPacket.counter = counter;
+  this->sendTries = sendTries;
 
-////fixed device id - duco remote with standby
-	//this->outIthoPacket.deviceId1[0] = 83;
-	//this->outIthoPacket.deviceId1[1] = 45;
-	//this->outIthoPacket.deviceId1[2] = 77;
-	//this->outIthoPacket.deviceId1[3] = 75;
-	//this->outIthoPacket.deviceId1[4] = 51;
-	//this->outIthoPacket.deviceId1[5] = 76;
-	////
-	//this->outIthoPacket.deviceId2[0] = 105;
-	//this->outIthoPacket.deviceId2[1] = 153;
-	//this->outIthoPacket.deviceId2[2] = 150;
-	//this->outIthoPacket.deviceId2[3] = 101;
-	//this->outIthoPacket.deviceId2[4] = 169;
-	//this->outIthoPacket.deviceId2[5] = 105;
-	//this->outIthoPacket.deviceId2[6] = 89;
-	//this->outIthoPacket.deviceId2[7] = 166;
+  this->outIthoPacket.deviceId[0] = 33;
+  this->outIthoPacket.deviceId[1] = 66;
+  this->outIthoPacket.deviceId[2] = 99;
 
-	//fixed device id - rft remote with timer
-	this->outIthoPacket.deviceId1[0] = 51;
-	this->outIthoPacket.deviceId1[1] = 83;
-	this->outIthoPacket.deviceId1[2] = 51;
-	this->outIthoPacket.deviceId1[3] = 43;
-	this->outIthoPacket.deviceId1[4] = 84;
-	this->outIthoPacket.deviceId1[5] = 204;
-	//
-	this->outIthoPacket.deviceId2[0] = 101;
-	this->outIthoPacket.deviceId2[1] = 89;
-	this->outIthoPacket.deviceId2[2] = 154;
-	this->outIthoPacket.deviceId2[3] = 153;
-	this->outIthoPacket.deviceId2[4] = 170;
-	this->outIthoPacket.deviceId2[5] = 105;
-	this->outIthoPacket.deviceId2[6] = 154;
-	this->outIthoPacket.deviceId2[7] = 86;
+  this->outIthoPacket.deviceType = 22;
+
 } //IthoCC1101
 
 // default destructor
@@ -56,908 +58,713 @@ IthoCC1101::~IthoCC1101()
 {
 } //~IthoCC1101
 
-void IthoCC1101::initSendMessage1()
+void IthoCC1101::initSendMessage(uint8_t len)
 {
-	/*
-	Configuration reverse engineered from remote print. The commands below are used by IthoDaalderop.
+  //finishTransfer();
+  writeCommand(CC1101_SIDLE);
+  delayMicroseconds(1);
+  writeRegister(CC1101_IOCFG0 , 0x2E);
+  delayMicroseconds(1);
+  writeRegister(CC1101_IOCFG1 , 0x2E);
+  delayMicroseconds(1);
+  writeCommand(CC1101_SIDLE);
+  writeCommand(CC1101_SPWD);
+  delayMicroseconds(2);
 
-	Base frequency		868.299866MHz
-	Channel				0
-	Channel spacing		199.951172kHz
-	Carrier frequency	868.299866MHz
-	Xtal frequency		26.000000MHz
-	Data rate			8.00896kBaud
-	Manchester			disabled
-	Modulation			2-FSK
-	Deviation			25.390625kHz
-	TX power			?
-	PA ramping			enabled
-	Whitening			disabled
-	*/
-	writeCommand(CC1101_SRES);
-	delayMicroseconds(1);
-	writeRegister(CC1101_IOCFG0 ,0x2E);		//High impedance (3-state)
-	writeRegister(CC1101_FREQ2 ,0x21);		//00100001	878MHz-927.8MHz
-	writeRegister(CC1101_FREQ1 ,0x65);		//01100101
-	writeRegister(CC1101_FREQ0 ,0x6A);		//01101010
-	writeRegister(CC1101_MDMCFG4 ,0x07);	//00000111
-	writeRegister(CC1101_MDMCFG3 ,0x43);	//01000011
-	writeRegister(CC1101_MDMCFG2 ,0x00);	//00000000	2-FSK, no manchester encoding/decoding, no preamble/sync
-	writeRegister(CC1101_MDMCFG1 ,0x22);	//00100010
-	writeRegister(CC1101_MDMCFG0 ,0xF8);	//11111000
-	writeRegister(CC1101_CHANNR ,0x00);		//00000000
-	writeRegister(CC1101_DEVIATN ,0x40);	//01000000
-	writeRegister(CC1101_FREND0 ,0x17);		//00010111	use index 7 in PA table
-	writeRegister(CC1101_MCSM0 ,0x18);		//00011000	PO timeout Approx. 146us - 171us, Auto calibrate When going from IDLE to RX or TX (or FSTXON)
-	writeRegister(CC1101_FSCAL3 ,0xA9);		//10101001
-	writeRegister(CC1101_FSCAL2 ,0x2A);		//00101010
-	writeRegister(CC1101_FSCAL1 ,0x00);		//00000000
-	writeRegister(CC1101_FSCAL0 ,0x11);		//00010001
-	writeRegister(CC1101_FSTEST ,0x59);		//01011001	For test only. Do not write to this register.
-	writeRegister(CC1101_TEST2 ,0x81);		//10000001	For test only. Do not write to this register.
-	writeRegister(CC1101_TEST1 ,0x35);		//00110101	For test only. Do not write to this register.
-	writeRegister(CC1101_TEST0 ,0x0B);		//00001011	For test only. Do not write to this register.
-	writeRegister(CC1101_PKTCTRL0 ,0x12);	//00010010	Enable infinite length packets, CRC disabled, Turn data whitening off, Serial Synchronous mode
-	writeRegister(CC1101_ADDR ,0x00);		//00000000
-	writeRegister(CC1101_PKTLEN ,0xFF);		//11111111	//Not used, no hardware packet handling
+  /*
+    Configuration reverse engineered from remote print. The commands below are used by IthoDaalderop.
+    Base frequency    868.299866MHz
+    Channel       0
+    Channel spacing   199.951172kHz
+    Carrier frequency 868.299866MHz
+    Xtal frequency    26.000000MHz
+    Data rate     38.3835kBaud
+    Manchester      disabled
+    Modulation      2-FSK
+    Deviation     50.781250kHz
+    TX power      ?
+    PA ramping      enabled
+    Whitening     disabled
+  */
+  writeCommand(CC1101_SRES);
+  delayMicroseconds(1);
+  writeRegister(CC1101_IOCFG0 , 0x2E);    //High impedance (3-state)
+  writeRegister(CC1101_FREQ2 , 0x21);   //00100001  878MHz-927.8MHz
+  writeRegister(CC1101_FREQ1 , 0x65);   //01100101
+  writeRegister(CC1101_FREQ0 , 0x6A);   //01101010
+  writeRegister(CC1101_MDMCFG4 , 0x5A); //difference compared to message1
+  writeRegister(CC1101_MDMCFG3 , 0x83); //difference compared to message1
+  writeRegister(CC1101_MDMCFG2 , 0x00); //00000000  2-FSK, no manchester encoding/decoding, no preamble/sync
+  writeRegister(CC1101_MDMCFG1 , 0x22); //00100010
+  writeRegister(CC1101_MDMCFG0 , 0xF8); //11111000
+  writeRegister(CC1101_CHANNR , 0x00);    //00000000
+  writeRegister(CC1101_DEVIATN , 0x50); //difference compared to message1
+  writeRegister(CC1101_FREND0 , 0x17);    //00010111  use index 7 in PA table
+  writeRegister(CC1101_MCSM0 , 0x18);   //00011000  PO timeout Approx. 146microseconds - 171microseconds, Auto calibrate When going from IDLE to RX or TX (or FSTXON)
+  writeRegister(CC1101_FSCAL3 , 0xA9);    //10101001
+  writeRegister(CC1101_FSCAL2 , 0x2A);    //00101010
+  writeRegister(CC1101_FSCAL1 , 0x00);    //00000000
+  writeRegister(CC1101_FSCAL0 , 0x11);    //00010001
+  writeRegister(CC1101_FSTEST , 0x59);    //01011001  For test only. Do not write to this register.
+  writeRegister(CC1101_TEST2 , 0x81);   //10000001  For test only. Do not write to this register.
+  writeRegister(CC1101_TEST1 , 0x35);   //00110101  For test only. Do not write to this register.
+  writeRegister(CC1101_TEST0 , 0x0B);   //00001011  For test only. Do not write to this register.
+  writeRegister(CC1101_PKTCTRL0 , 0x12);  //00010010  Enable infinite length packets, CRC disabled, Turn data whitening off, Serial Synchronous mode
+  writeRegister(CC1101_ADDR , 0x00);    //00000000
+  writeRegister(CC1101_PKTLEN , 0xFF);    //11111111  //Not used, no hardware packet handling
 
-	//0x6F,0x26,0x2E,0x8C,0x87,0xCD,0xC7,0xC0
-	writeBurstRegister(CC1101_PATABLE | CC1101_WRITE_BURST, (uint8_t*)ithoPaTableSend, 8);
+  //0x6F,0x26,0x2E,0x8C,0x87,0xCD,0xC7,0xC0
+  writeBurstRegister(CC1101_PATABLE | CC1101_WRITE_BURST, (uint8_t*)ithoPaTableSend, 8);
 
-	writeCommand(CC1101_SIDLE);
-	writeCommand(CC1101_SIDLE);
-	writeCommand(CC1101_SIDLE);
+  //difference, message1 sends a STX here
+  writeCommand(CC1101_SIDLE);
+  writeCommand(CC1101_SIDLE);
 
-	writeRegister(CC1101_MDMCFG4 ,0x08);	//00001000
-	writeRegister(CC1101_MDMCFG3 ,0x43);	//01000011
-	writeRegister(CC1101_DEVIATN ,0x40);	//01000000
-	writeRegister(CC1101_IOCFG0 ,0x2D);		//GDO0_Z_EN_N. When this output is 0, GDO0 is configured as input (for serial TX data).
-	writeRegister(CC1101_IOCFG1 ,0x0B);		//Serial Clock. Synchronous to the data in synchronous serial mode.
+  writeRegister(CC1101_MDMCFG4 , 0x5A); //difference compared to message1
+  writeRegister(CC1101_MDMCFG3 , 0x83); //difference compared to message1
+  writeRegister(CC1101_DEVIATN , 0x50); //difference compared to message1
+  writeRegister(CC1101_IOCFG0 , 0x2D);    //GDO0_Z_EN_N. When this output is 0, GDO0 is configured as input (for serial TX data).
+  writeRegister(CC1101_IOCFG1 , 0x0B);    //Serial Clock. Synchronous to the data in synchronous serial mode.
 
-	writeCommand(CC1101_STX);
-	writeCommand(CC1101_SIDLE);
-	delayMicroseconds(1);
-	writeCommand(CC1101_SIDLE);
+  writeCommand(CC1101_STX);
+  writeCommand(CC1101_SIDLE);
 
-	writeRegister(CC1101_MDMCFG4 ,0x08);	//00001000
-	writeRegister(CC1101_MDMCFG3 ,0x43);	//01000011
-	writeRegister(CC1101_DEVIATN ,0x40);	//01000000
-	//writeRegister(CC1101_IOCFG0 ,0x2D);		//GDO0_Z_EN_N. When this output is 0, GDO0 is configured as input (for serial TX data).
-	//writeRegister(CC1101_IOCFG1 ,0x0B);		//Serial Clock. Synchronous to the data in synchronous serial mode.
+  writeRegister(CC1101_MDMCFG4 , 0x5A); //difference compared to message1
+  writeRegister(CC1101_MDMCFG3 , 0x83); //difference compared to message1
+  writeRegister(CC1101_DEVIATN , 0x50); //difference compared to message1
+  //writeRegister(CC1101_IOCFG0 ,0x2D);   //GDO0_Z_EN_N. When this output is 0, GDO0 is configured as input (for serial TX data).
+  //writeRegister(CC1101_IOCFG1 ,0x0B);   //Serial Clock. Synchronous to the data in synchronous serial mode.
 
-	//Itho is using serial mode for transmit. We want to use the TX FIFO with fixed packet length for simplicity.
-	writeRegister(CC1101_IOCFG0 ,0x2E);
-	writeRegister(CC1101_IOCFG1 ,0x2E);
-	writeRegister(CC1101_PKTLEN , 19);
-	writeRegister(CC1101_PKTCTRL0 ,0x00);
-	writeRegister(CC1101_PKTCTRL1 ,0x00);
-}
+  //Itho is using serial mode for transmit. We want to use the TX FIFO with fixed packet length for simplicity.
+  writeRegister(CC1101_IOCFG0 , 0x2E);
+  writeRegister(CC1101_IOCFG1 , 0x2E);
+  writeRegister(CC1101_PKTCTRL0 , 0x00);
+  writeRegister(CC1101_PKTCTRL1 , 0x00);
 
-void IthoCC1101::initSendMessage2(IthoCommand command)
-{
-	//finishTransfer();
-	writeCommand(CC1101_SIDLE);
-	delayMicroseconds(1);
-	writeRegister(CC1101_IOCFG0 ,0x2E);
-	delayMicroseconds(1);
-	writeRegister(CC1101_IOCFG1 ,0x2E);
-	delayMicroseconds(1);
-	writeCommand(CC1101_SIDLE);
-	writeCommand(CC1101_SPWD);
-	delayMicroseconds(2);
+  writeRegister(CC1101_PKTLEN , len);
 
-	/*
-	Configuration reverse engineered from remote print. The commands below are used by IthoDaalderop.
-
-	Base frequency		868.299866MHz
-	Channel				0
-	Channel spacing		199.951172kHz
-	Carrier frequency	868.299866MHz
-	Xtal frequency		26.000000MHz
-	Data rate			38.3835kBaud
-	Manchester			disabled
-	Modulation			2-FSK
-	Deviation			50.781250kHz
-	TX power			?
-	PA ramping			enabled
-	Whitening			disabled
-	*/
-	writeCommand(CC1101_SRES);
-	delayMicroseconds(1);
-	writeRegister(CC1101_IOCFG0 ,0x2E);		//High impedance (3-state)
-	writeRegister(CC1101_FREQ2 ,0x21);		//00100001	878MHz-927.8MHz
-	writeRegister(CC1101_FREQ1 ,0x65);		//01100101
-	writeRegister(CC1101_FREQ0 ,0x6A);		//01101010
-	writeRegister(CC1101_MDMCFG4 ,0x5A);	//difference compared to message1
-	writeRegister(CC1101_MDMCFG3 ,0x83);	//difference compared to message1
-	writeRegister(CC1101_MDMCFG2 ,0x00);	//00000000	2-FSK, no manchester encoding/decoding, no preamble/sync
-	writeRegister(CC1101_MDMCFG1 ,0x22);	//00100010
-	writeRegister(CC1101_MDMCFG0 ,0xF8);	//11111000
-	writeRegister(CC1101_CHANNR ,0x00);		//00000000
-	writeRegister(CC1101_DEVIATN ,0x50);	//difference compared to message1
-	writeRegister(CC1101_FREND0 ,0x17);		//00010111	use index 7 in PA table
-	writeRegister(CC1101_MCSM0 ,0x18);		//00011000	PO timeout Approx. 146us - 171us, Auto calibrate When going from IDLE to RX or TX (or FSTXON)
-	writeRegister(CC1101_FSCAL3 ,0xA9);		//10101001
-	writeRegister(CC1101_FSCAL2 ,0x2A);		//00101010
-	writeRegister(CC1101_FSCAL1 ,0x00);		//00000000
-	writeRegister(CC1101_FSCAL0 ,0x11);		//00010001
-	writeRegister(CC1101_FSTEST ,0x59);		//01011001	For test only. Do not write to this register.
-	writeRegister(CC1101_TEST2 ,0x81);		//10000001	For test only. Do not write to this register.
-	writeRegister(CC1101_TEST1 ,0x35);		//00110101	For test only. Do not write to this register.
-	writeRegister(CC1101_TEST0 ,0x0B);		//00001011	For test only. Do not write to this register.
-	writeRegister(CC1101_PKTCTRL0 ,0x12);	//00010010	Enable infinite length packets, CRC disabled, Turn data whitening off, Serial Synchronous mode
-	writeRegister(CC1101_ADDR ,0x00);		//00000000
-	writeRegister(CC1101_PKTLEN ,0xFF);		//11111111	//Not used, no hardware packet handling
-
-	//0x6F,0x26,0x2E,0x8C,0x87,0xCD,0xC7,0xC0
-	writeBurstRegister(CC1101_PATABLE | CC1101_WRITE_BURST, (uint8_t*)ithoPaTableSend, 8);
-
-	//difference, message1 sends a STX here
-	writeCommand(CC1101_SIDLE);
-	writeCommand(CC1101_SIDLE);
-
-	writeRegister(CC1101_MDMCFG4 ,0x5A);	//difference compared to message1
-	writeRegister(CC1101_MDMCFG3 ,0x83);	//difference compared to message1
-	writeRegister(CC1101_DEVIATN ,0x50);	//difference compared to message1
-	writeRegister(CC1101_IOCFG0 ,0x2D);		//GDO0_Z_EN_N. When this output is 0, GDO0 is configured as input (for serial TX data).
-	writeRegister(CC1101_IOCFG1 ,0x0B);		//Serial Clock. Synchronous to the data in synchronous serial mode.
-
-	writeCommand(CC1101_STX);
-	writeCommand(CC1101_SIDLE);
-
-	writeRegister(CC1101_MDMCFG4 ,0x5A);	//difference compared to message1
-	writeRegister(CC1101_MDMCFG3 ,0x83);	//difference compared to message1
-	writeRegister(CC1101_DEVIATN ,0x50);	//difference compared to message1
-	//writeRegister(CC1101_IOCFG0 ,0x2D);		//GDO0_Z_EN_N. When this output is 0, GDO0 is configured as input (for serial TX data).
-	//writeRegister(CC1101_IOCFG1 ,0x0B);		//Serial Clock. Synchronous to the data in synchronous serial mode.
-
-	//Itho is using serial mode for transmit. We want to use the TX FIFO with fixed packet length for simplicity.
-	writeRegister(CC1101_IOCFG0 ,0x2E);
-	writeRegister(CC1101_IOCFG1 ,0x2E);
-	writeRegister(CC1101_PKTCTRL0 ,0x00);
-	writeRegister(CC1101_PKTCTRL1 ,0x00);
-
-	switch (command)
-	{
-		case IthoJoin:
-			writeRegister(CC1101_PKTLEN , 72);
-			break;
-
-		case IthoLeave:
-			writeRegister(CC1101_PKTLEN , 57);
-			break;
-
-		default:
-			writeRegister(CC1101_PKTLEN , 50);
-			break;
-	}
 }
 
 void IthoCC1101::finishTransfer()
 {
-	writeCommand(CC1101_SIDLE);
-	delayMicroseconds(1);
+  writeCommand(CC1101_SIDLE);
+  delayMicroseconds(1);
 
-	writeRegister(CC1101_IOCFG0 ,0x2E);
-	writeRegister(CC1101_IOCFG1 ,0x2E);
+  writeRegister(CC1101_IOCFG0 , 0x2E);
+  writeRegister(CC1101_IOCFG1 , 0x2E);
 
-	writeCommand(CC1101_SIDLE);
-	writeCommand(CC1101_SPWD);
+  writeCommand(CC1101_SIDLE);
+  writeCommand(CC1101_SPWD);
 }
 
 void IthoCC1101::initReceive()
 {
-	/*
-	Configuration reverse engineered from RFT print.
+  /*
+    Configuration reverse engineered from RFT print.
 
-	Base frequency		868.299866MHz
-	Channel				0
-	Channel spacing		199.951172kHz
-	Carrier frequency	868.299866MHz
-	Xtal frequency		26.000000MHz
-	Data rate			38.3835kBaud
-	RX filter BW		325.000000kHz
-	Manchester			disabled
-	Modulation			2-FSK
-	Deviation			50.781250kHz
-	TX power			0x6F,0x26,0x2E,0x7F,0x8A,0x84,0xCA,0xC4
-	PA ramping			enabled
-	Whitening			disabled
-	*/
-	writeCommand(CC1101_SRES);
+    Base frequency    868.299866MHz
+    Channel       0
+    Channel spacing   199.951172kHz
+    Carrier frequency 868.299866MHz
+    Xtal frequency    26.000000MHz
+    Data rate     38.3835kBaud
+    RX filter BW    325.000000kHz
+    Manchester      disabled
+    Modulation      2-FSK
+    Deviation     50.781250kHz
+    TX power      0x6F,0x26,0x2E,0x7F,0x8A,0x84,0xCA,0xC4
+    PA ramping      enabled
+    Whitening     disabled
+  */
+  writeCommand(CC1101_SRES);
 
-	writeRegister(CC1101_TEST0 ,0x09);
-	writeRegister(CC1101_FSCAL2 ,0x00);
+  writeRegister(CC1101_TEST0 , 0x09);
+  writeRegister(CC1101_FSCAL2 , 0x00);
 
-	//0x6F,0x26,0x2E,0x7F,0x8A,0x84,0xCA,0xC4
-	writeBurstRegister(CC1101_PATABLE | CC1101_WRITE_BURST, (uint8_t*)ithoPaTableReceive, 8);
+  //0x6F,0x26,0x2E,0x7F,0x8A,0x84,0xCA,0xC4
+  writeBurstRegister(CC1101_PATABLE | CC1101_WRITE_BURST, (uint8_t*)ithoPaTableReceive, 8);
 
-	writeCommand(CC1101_SCAL);
+  writeCommand(CC1101_SCAL);
 
-	//wait for calibration to finish
-	while ((readRegisterWithSyncProblem(CC1101_MARCSTATE, CC1101_STATUS_REGISTER)) != CC1101_MARCSTATE_IDLE) delay(0);
+  //wait for calibration to finish
+  while ((readRegisterWithSyncProblem(CC1101_MARCSTATE, CC1101_STATUS_REGISTER)) != CC1101_MARCSTATE_IDLE) yield();
 
-	writeRegister(CC1101_FSCAL2 ,0x00);
-	writeRegister(CC1101_MCSM0 ,0x18);			//no auto calibrate
-	writeRegister(CC1101_FREQ2 ,0x21);
-	writeRegister(CC1101_FREQ1 ,0x65);
-	writeRegister(CC1101_FREQ0 ,0x6A);
-	writeRegister(CC1101_IOCFG0 ,0x2E);			//High impedance (3-state)
-	writeRegister(CC1101_IOCFG2 ,0x00);			//Assert when RX FIFO is filled or above the RX FIFO threshold. Deassert when (0x00): RX FIFO is drained below threshold, or (0x01): deassert when RX FIFO is empty.
-	writeRegister(CC1101_FSCTRL1 ,0x06);
-	writeRegister(CC1101_FSCTRL0 ,0x00);
-	writeRegister(CC1101_MDMCFG4 ,0xE8);
-	writeRegister(CC1101_MDMCFG3 ,0x43);
-	writeRegister(CC1101_MDMCFG2 ,0x00);		//Enable digital DC blocking filter before demodulator, 2-FSK, Disable Manchester encoding/decoding, No preamble/sync
-	writeRegister(CC1101_MDMCFG1 ,0x22);		//Disable FEC
-	writeRegister(CC1101_MDMCFG0 ,0xF8);
-	writeRegister(CC1101_CHANNR ,0x00);
-	writeRegister(CC1101_DEVIATN ,0x40);
-	writeRegister(CC1101_FREND1 ,0x56);
-	writeRegister(CC1101_FREND0 ,0x17);
-	writeRegister(CC1101_MCSM0 ,0x18);			//no auto calibrate
-	writeRegister(CC1101_FOCCFG ,0x16);
-	writeRegister(CC1101_BSCFG ,0x6C);
-	writeRegister(CC1101_AGCCTRL2 ,0x43);
-	writeRegister(CC1101_AGCCTRL1 ,0x40);
-	writeRegister(CC1101_AGCCTRL0 ,0x91);
-	writeRegister(CC1101_FSCAL3 ,0xA9);
-//	writeRegister(CC1101_FSCAL3 ,0xE9); //DUCO?
-	writeRegister(CC1101_FSCAL2 ,0x2A);
-	writeRegister(CC1101_FSCAL1 ,0x00);
-	writeRegister(CC1101_FSCAL0 ,0x1F); 		//Implemented latest changes in code from Supersjimmie, previous version was based on slightly older plugin code: https://github.com/supersjimmie/IthoEcoFanRFT/commit/7ae2c9e34e13a628988caa28f975c9929fb9676d
-	writeRegister(CC1101_FSTEST ,0x59);
-	writeRegister(CC1101_TEST2 ,0x81);
-	writeRegister(CC1101_TEST1 ,0x35);
-	writeRegister(CC1101_TEST0 ,0x0B);
-	writeRegister(CC1101_PKTCTRL1 ,0x04);		//No address check, Append two bytes with status RSSI/LQI/CRC OK,
-	writeRegister(CC1101_PKTCTRL0 ,0x32);		//Infinite packet length mode, CRC disabled for TX and RX, No data whitening, Asynchronous serial mode, Data in on GDO0 and data out on either of the GDOx pins
-	writeRegister(CC1101_ADDR ,0x00);
-	writeRegister(CC1101_PKTLEN ,0xFF);
-	writeRegister(CC1101_TEST0 ,0x09);
+  writeRegister(CC1101_FSCAL2 , 0x00);
+  writeRegister(CC1101_MCSM0 , 0x18);     //no auto calibrate
+  writeRegister(CC1101_FREQ2 , 0x21);
+  writeRegister(CC1101_FREQ1 , 0x65);
+  writeRegister(CC1101_FREQ0 , 0x6A);
+  writeRegister(CC1101_IOCFG0 , 0x2E);      //High impedance (3-state)
+  writeRegister(CC1101_IOCFG2 , 0x06);      //0x06 Assert when sync word has been sent / received, and de-asserts at the end of the packet.
+  writeRegister(CC1101_FSCTRL1 , 0x06);
+  writeRegister(CC1101_FSCTRL0 , 0x00);
+  writeRegister(CC1101_MDMCFG4 , 0x5A);
+  writeRegister(CC1101_MDMCFG3 , 0x83);
+  writeRegister(CC1101_MDMCFG2 , 0x00);   //Enable digital DC blocking filter before demodulator, 2-FSK, Disable Manchester encoding/decoding, No preamble/sync
+  writeRegister(CC1101_MDMCFG1 , 0x22);   //Disable FEC
+  writeRegister(CC1101_MDMCFG0 , 0xF8);
+  writeRegister(CC1101_CHANNR , 0x00);
+  writeRegister(CC1101_DEVIATN , 0x50);
+  writeRegister(CC1101_FREND1 , 0x56);
+  writeRegister(CC1101_FREND0 , 0x17);
+  writeRegister(CC1101_MCSM0 , 0x18);     //no auto calibrate
+  writeRegister(CC1101_FOCCFG , 0x16);
+  writeRegister(CC1101_BSCFG , 0x6C);
+  writeRegister(CC1101_AGCCTRL2 , 0x43);
+  writeRegister(CC1101_AGCCTRL1 , 0x40);
+  writeRegister(CC1101_AGCCTRL0 , 0x91);
+  writeRegister(CC1101_FSCAL3 , 0xE9);
+  writeRegister(CC1101_FSCAL2 , 0x2A);
+  writeRegister(CC1101_FSCAL1 , 0x00);
+  writeRegister(CC1101_FSCAL0 , 0x11);
+  writeRegister(CC1101_FSTEST , 0x59);
+  writeRegister(CC1101_TEST2 , 0x81);
+  writeRegister(CC1101_TEST1 , 0x35);
+  writeRegister(CC1101_TEST0 , 0x0B);
+  writeRegister(CC1101_PKTCTRL1 , 0x04);    //No address check, Append two bytes with status RSSI/LQI/CRC OK,
+  writeRegister(CC1101_PKTCTRL0 , 0x32);    //Infinite packet length mode, CRC disabled for TX and RX, No data whitening, Asynchronous serial mode, Data in on GDO0 and data out on either of the GDOx pins
+  writeRegister(CC1101_ADDR , 0x00);
+  writeRegister(CC1101_PKTLEN , 0xFF);
+  writeRegister(CC1101_TEST0 , 0x09);
 
-	writeCommand(CC1101_SCAL);
+  writeCommand(CC1101_SCAL);
 
-	//wait for calibration to finish
-	while ((readRegisterWithSyncProblem(CC1101_MARCSTATE, CC1101_STATUS_REGISTER)) != CC1101_MARCSTATE_IDLE) delay(0);
+  //wait for calibration to finish
+  while ((readRegisterWithSyncProblem(CC1101_MARCSTATE, CC1101_STATUS_REGISTER)) != CC1101_MARCSTATE_IDLE) yield();
 
-	writeRegister(CC1101_MCSM0 ,0x18);			//no auto calibrate
+  writeRegister(CC1101_MCSM0 , 0x18);     //no auto calibrate
 
-	writeCommand(CC1101_SIDLE);
-	writeCommand(CC1101_SIDLE);
+  writeCommand(CC1101_SIDLE);
+  writeCommand(CC1101_SIDLE);
 
-	writeRegister(CC1101_MDMCFG2 ,0x00);		//Enable digital DC blocking filter before demodulator, 2-FSK, Disable Manchester encoding/decoding, No preamble/sync
-	writeRegister(CC1101_IOCFG0 ,0x0D);			//Serial Data Output. Used for asynchronous serial mode.
+  writeRegister(CC1101_MDMCFG2 , 0x00);   //Enable digital DC blocking filter before demodulator, 2-FSK, Disable Manchester encoding/decoding, No preamble/sync
+  writeRegister(CC1101_IOCFG0 , 0x0D);      //Serial Data Output. Used for asynchronous serial mode.
 
-	writeCommand(CC1101_SRX);
+  writeCommand(CC1101_SRX);
 
-	while ((readRegisterWithSyncProblem(CC1101_MARCSTATE, CC1101_STATUS_REGISTER)) != CC1101_MARCSTATE_RX) delay(0);
+  while ((readRegisterWithSyncProblem(CC1101_MARCSTATE, CC1101_STATUS_REGISTER)) != CC1101_MARCSTATE_RX) yield();
 
-//	initReceiveMessage2(IthoUnknown);
-	initReceiveMessage2(ithomsg_unknown);
+  initReceiveMessage();
 }
 
-//void  IthoCC1101::initReceiveMessage2(IthoCommand expectedCommand)
-void  IthoCC1101::initReceiveMessage2(IthoMessageType expectedMessageType)
+void  IthoCC1101::initReceiveMessage()
 {
-	uint8_t marcState;
+  uint8_t marcState;
 
-	writeCommand(CC1101_SIDLE);	//idle
+  writeCommand(CC1101_SIDLE); //idle
 
-	//set datarate
-	writeRegister(CC1101_MDMCFG4 ,0x9A); // set kBaud	Update: implemented latest changes in code from Supersjimmie, previous version was based on slightly older plugin code: https://github.com/supersjimmie/IthoEcoFanRFT/commit/7ae2c9e34e13a628988caa28f975c9929fb9676d
-	writeRegister(CC1101_MDMCFG3 ,0x83); // set kBaud
-	writeRegister(CC1101_DEVIATN ,0x50);
+  //set datarate
+  writeRegister(CC1101_MDMCFG4 , 0x5A); // set kBaud
+  writeRegister(CC1101_MDMCFG3 , 0x83); // set kBaud
+  writeRegister(CC1101_DEVIATN , 0x50);
 
- 	//set fifo mode with fixed packet length and sync bytes
-	writeRegister(CC1101_PKTLEN ,42);			//42 bytes message (sync at beginning of message is removed by CC1101)
-	receiveState = ExpectNormalCommand;
+  //set fifo mode with fixed packet length and sync bytes
+  writeRegister(CC1101_PKTLEN , 63);      //63 bytes message (sync at beginning of message is removed by CC1101)
 
-	//set fifo mode with fixed packet length and sync bytes
-	writeRegister(CC1101_PKTCTRL0 ,0x00);
-	writeRegister(CC1101_SYNC1 ,this->remoteSync1);
-//	writeRegister(CC1101_SYNC1 ,170);			//message2 byte6 -- if not working change to 170, use 172 for remote with 'niet-thuis' function
-//	writeRegister(CC1101_SYNC1 ,172);			//message2 byte6
-	writeRegister(CC1101_SYNC0 ,171);			//message2 byte7
-	writeRegister(CC1101_MDMCFG2 ,0x02);
-	writeRegister(CC1101_PKTCTRL1 ,0x00);
+  //set fifo mode with fixed packet length and sync bytes
+  writeRegister(CC1101_PKTCTRL0 , 0x00);
+  writeRegister(CC1101_SYNC1 , SYNC1);
+  writeRegister(CC1101_SYNC0 , SYNC0);
+  writeRegister(CC1101_MDMCFG2 , MDMCFG2);
+  writeRegister(CC1101_PKTCTRL1 , 0x00);
 
-	writeCommand(CC1101_SRX); //switch to RX state
+  writeCommand(CC1101_SRX); //switch to RX state
 
-	// Check that the RX state has been entered
-	while (((marcState = readRegisterWithSyncProblem(CC1101_MARCSTATE, CC1101_STATUS_REGISTER)) & CC1101_BITS_MARCSTATE) != CC1101_MARCSTATE_RX)
-	{
-		if (marcState == CC1101_MARCSTATE_RXFIFO_OVERFLOW) // RX_OVERFLOW
-			writeCommand(CC1101_SFRX); //flush RX buffer
-	}
+  // Check that the RX state has been entered
+  while (((marcState = readRegisterWithSyncProblem(CC1101_MARCSTATE, CC1101_STATUS_REGISTER)) & CC1101_BITS_MARCSTATE) != CC1101_MARCSTATE_RX)
+  {
+    if (marcState == CC1101_MARCSTATE_RXFIFO_OVERFLOW) // RX_OVERFLOW
+      writeCommand(CC1101_SFRX); //flush RX buffer
+  }
 }
 
-bool IthoCC1101::checkForNewPacket()
-{
-	if (receiveData(&inMessage2, 42))
-	{
-		parseMessageCommand();
-		initReceiveMessage2(ithomsg_unknown);
-		return true;
-	}
-
-	return false;
+bool IthoCC1101::checkForNewPacket() {
+  if (receiveData(&inMessage, 63) && parseMessageCommand()) {
+    initReceiveMessage();
+    return true;
+  }
+  return false;
 }
 
-void IthoCC1101::parseMessageCommand()
-{
-	bool isPowerCommand = true;
-	bool isHighCommand = true;
-	bool isMediumCommand = true;
-	bool isLowCommand = true;
-	bool isStandByCommand = true;
-	bool isTimer1Command = true;
-	bool isTimer2Command = true;
-	bool isTimer3Command = true;
-	bool isJoinCommand = true;
-	bool isLeaveCommand = true;
+bool IthoCC1101::parseMessageCommand() {
 
-	//device id
-	memcpy(inIthoPacket.deviceId2, &inMessage2.data[8], sizeof inIthoPacket.deviceId2);
+  messageDecode(&inMessage, &inIthoPacket);
 
-	//counter1
-	inIthoPacket.counter = calculateMessageCounter(inMessage2.data[16], inMessage2.data[17], (inMessage2.data[16] & 0b11110000));
+  //deviceType of message type?
+  inIthoPacket.deviceType  = inIthoPacket.dataDecoded[0];
 
-	//match received commandBytes from inMessage2 [offset is +18] with known command bytes
-	//and for simpcity sake we ignore the first 11 bytes: the last 4 bytes are still unique
-	for (int i=11; i<15; i++)
-	{
-		if (inMessage2.data[i+18] != ithoMessage2PowerCommandBytes[i])   isPowerCommand = false;
-		if (inMessage2.data[i+18] != ithoMessage2HighCommandBytes[i])    isHighCommand = false;
-		if (inMessage2.data[i+18] != ithoMessage2MediumCommandBytes[i])  isMediumCommand = false;
-		if (inMessage2.data[i+18] != ithoMessage2LowCommandBytes[i])     isLowCommand = false;
-		if (inMessage2.data[i+18] != ithoMessage2StandByCommandBytes[i]) isStandByCommand = false;
-		if (inMessage2.data[i+18] != ithoMessage2Timer1CommandBytes[i])  isTimer1Command = false;
-		if (inMessage2.data[i+18] != ithoMessage2Timer2CommandBytes[i])  isTimer2Command = false;
-		if (inMessage2.data[i+18] != ithoMessage2Timer3CommandBytes[i])  isTimer3Command = false;
-		if (inMessage2.data[i+18] != ithoMessage2JoinCommandBytes[i])    isJoinCommand = false;
-		if (inMessage2.data[i+18] != ithoMessage2LeaveCommandBytes[i])   isLeaveCommand = false;
-	}
+  //deviceID
+  inIthoPacket.deviceId[0] = inIthoPacket.dataDecoded[1];
+  inIthoPacket.deviceId[1] = inIthoPacket.dataDecoded[2];
+  inIthoPacket.deviceId[2] = inIthoPacket.dataDecoded[3];
 
-	//determine command
-	inIthoPacket.command = IthoUnknown;
-	if (isPowerCommand)   inIthoPacket.command = IthoFull;
-	if (isHighCommand)    inIthoPacket.command = IthoHigh;
-	if (isMediumCommand)  inIthoPacket.command = IthoMedium;
-	if (isLowCommand)     inIthoPacket.command = IthoLow;
-	if (isStandByCommand) inIthoPacket.command = IthoStandby;
-	if (isTimer1Command)  inIthoPacket.command = IthoTimer1;
-	if (isTimer2Command)  inIthoPacket.command = IthoTimer2;
-	if (isTimer3Command)  inIthoPacket.command = IthoTimer3;
-	if (isJoinCommand)    inIthoPacket.command = IthoJoin;
-	if (isLeaveCommand)   inIthoPacket.command = IthoLeave;
+  //counter1
+  inIthoPacket.counter = inIthoPacket.dataDecoded[4];
+
+  bool isHighCommand      = checkIthoCommand(&inIthoPacket, ithoMessageHighCommandBytes);
+  bool isRVHighCommand    = checkIthoCommand(&inIthoPacket, ithoMessageRVHighCommandBytes);
+  bool isMediumCommand    = checkIthoCommand(&inIthoPacket, ithoMessageMediumCommandBytes);
+  bool isRVMediumCommand  = checkIthoCommand(&inIthoPacket, ithoMessageRVMediumCommandBytes);
+  bool isLowCommand       = checkIthoCommand(&inIthoPacket, ithoMessageLowCommandBytes);
+  bool isRVLowCommand     = checkIthoCommand(&inIthoPacket, ithoMessageRVLowCommandBytes);
+  bool isRVAutoCommand    = checkIthoCommand(&inIthoPacket, ithoMessageRVAutoCommandBytes);
+  bool isStandByCommand   = checkIthoCommand(&inIthoPacket, ithoMessageStandByCommandBytes);
+  bool isTimer1Command    = checkIthoCommand(&inIthoPacket, ithoMessageTimer1CommandBytes);
+  bool isTimer2Command    = checkIthoCommand(&inIthoPacket, ithoMessageTimer2CommandBytes);
+  bool isTimer3Command    = checkIthoCommand(&inIthoPacket, ithoMessageTimer3CommandBytes);
+  bool isJoinCommand      = checkIthoCommand(&inIthoPacket, ithoMessageJoinCommandBytes);
+  bool isJoin2Command     = checkIthoCommand(&inIthoPacket, ithoMessageJoin2CommandBytes);
+  bool isRVJoinCommand    = checkIthoCommand(&inIthoPacket, ithoMessageRVJoinCommandBytes);
+  bool isLeaveCommand     = checkIthoCommand(&inIthoPacket, ithoMessageLeaveCommandBytes);
+
+  //determine command
+  inIthoPacket.command = IthoUnknown;
+  if (isHighCommand)     inIthoPacket.command = IthoHigh;
+  if (isRVHighCommand)   inIthoPacket.command = IthoHigh;
+  if (isMediumCommand)   inIthoPacket.command = IthoMedium;
+  if (isRVMediumCommand) inIthoPacket.command = IthoMedium;
+  if (isLowCommand)      inIthoPacket.command = IthoLow;
+  if (isRVLowCommand)    inIthoPacket.command = IthoLow;
+  if (isRVAutoCommand)   inIthoPacket.command = IthoStandby;
+  if (isStandByCommand)  inIthoPacket.command = IthoStandby;
+  if (isTimer1Command)   inIthoPacket.command = IthoTimer1;
+  if (isTimer2Command)   inIthoPacket.command = IthoTimer2;
+  if (isTimer3Command)   inIthoPacket.command = IthoTimer3;
+  if (isJoinCommand)     inIthoPacket.command = IthoJoin;
+  if (isJoin2Command)    inIthoPacket.command = IthoJoin;
+  if (isRVJoinCommand)   inIthoPacket.command = IthoJoin;
+  if (isLeaveCommand)    inIthoPacket.command = IthoLeave;
+
+#if defined (CRC_FILTER)
+  uint8_t mLen = 0;
+  if (isPowerCommand || isHighCommand || isMediumCommand || isLowCommand || isStandByCommand || isTimer1Command || isTimer2Command || isTimer3Command) {
+    mLen = 11;
+  }
+  else if (isJoinCommand || isJoin2Command) {
+    mLen = 20;
+  }
+  else if (isLeaveCommand) {
+    mLen = 14;
+  }
+  else {
+    return true;
+  }
+  if (getCounter2(&inIthoPacket, mLen) != inIthoPacket.dataDecoded[mLen]) {
+    inIthoPacket.command = IthoUnknown;
+    return false;
+  }
+#endif
+
+  return true;
+}
+
+bool IthoCC1101::checkIthoCommand(IthoPacket *itho, const uint8_t commandBytes[]) {
+  uint8_t offset = 0;
+  if (itho->deviceType == 28 || itho->deviceType == 24) offset = 2;
+  for (int i = 4; i < 6; i++)
+  {
+    //if (i == 2 || i == 3) continue; //skip byte3 and byte4, rft-rv and co2-auto remote device seem to sometimes have a different number there
+    if ( (itho->dataDecoded[i + 5 + offset] != commandBytes[i]) && (itho->dataDecodedChk[i + 5 + offset] != commandBytes[i]) ) {
+      return false;
+    }
+  }
+  return true;
 }
 
 void IthoCC1101::sendCommand(IthoCommand command)
 {
-	//CC1101Packet outMessage1;
-	CC1101Packet outMessage2;
-	uint8_t maxTries = sendTries;
-	uint8_t delaytime = 40;
+  CC1101Packet outMessage;
+  uint8_t maxTries = sendTries;
+  uint8_t delaytime = 40;
 
-	//update itho packet data
-	outIthoPacket.previous = outIthoPacket.command;
-	outIthoPacket.messageType = ithomsg_unknown;
-	outIthoPacket.command = command;
-	outIthoPacket.counter += 1;
+  //update itho packet data
+  outIthoPacket.command = command;
+  outIthoPacket.counter += 1;
 
-	//get message1 bytes
-	//createMessageStart(&outIthoPacket, &outMessage1);
+  //get message2 bytes
+  switch (command)
+  {
+    case IthoJoin:
+      createMessageJoin(&outIthoPacket, &outMessage);
+      break;
 
-	//get message2 bytes
-	switch (command)
-	{
-		case IthoJoin:
-			createMessageJoin(&outIthoPacket, &outMessage2);
-			break;
+    case IthoLeave:
+      createMessageLeave(&outIthoPacket, &outMessage);
+      //the leave command needs to be transmitted for 1 second according the manual
+      maxTries = 30;
+      delaytime = 4;
+      break;
 
-		case IthoLeave:
-			createMessageLeave(&outIthoPacket, &outMessage2);
-			//the leave command needs to be transmitted for 1 second according the manual
-			maxTries = 30;
-			delaytime = 4;
-			break;
+    default:
+      createMessageCommand(&outIthoPacket, &outMessage);
+      break;
+  }
 
-		default:
-			createMessageCommand(&outIthoPacket, &outMessage2);
-			break;
-	}
+  //send messages
+  for (int i = 0; i < maxTries; i++)
+  {
 
-	//send messages
-	for (int i=0;i<maxTries;i++)
-	{
-/*		//message1
-		initSendMessage1();
-		sendData(&outMessage1);
+    //message2
+    initSendMessage(outMessage.length);
+    sendData(&outMessage);
 
-		delay(4); // delay between message1/2 */
-
-		//message2
-		initSendMessage2(outIthoPacket.command);
-		sendData(&outMessage2);
-
-		finishTransfer();
-		delay(delaytime);
-	}
-	//initReceive(); //SV - moved this back to the plugin, so I can call it whenever I want to see if this prevents crashes in mega-20191208
+    finishTransfer();
+    delay(delaytime);
+  }
+  //initReceive(); SV - I call this from the ESPEasy plugin to prevent crashes
 }
 
 void IthoCC1101::createMessageStart(IthoPacket *itho, CC1101Packet *packet)
 {
-	packet->length = 19;
 
-	//fixed
-	packet->data[0] = 170;
-	packet->data[1] = 170;
-	packet->data[2] = 170;
-	packet->data[3] = 173;
+  //fixed, set start structure in data buffer manually
+  for (uint8_t i = 0; i < 7; i++) {
+    packet->data[i] = 170;
+  }
+  packet->data[7] = 171;
+  packet->data[8] = 254;
+  packet->data[9] = 0;
+  packet->data[10] = 179;
+  packet->data[11] = 42;
+  packet->data[12] = 171;
+  packet->data[13] = 42;
 
-	//device id message 1
-	packet->data[4] = itho->deviceId1[0];
-	packet->data[5] = itho->deviceId1[1];
-	packet->data[6] = itho->deviceId1[2];
-	packet->data[7] = itho->deviceId1[3];
-	packet->data[8] = itho->deviceId1[4];
-	packet->data[9] = itho->deviceId1[5];	//last bit is part of command
+  //[start of command specific data]
 
-	//command
-	uint8_t *commandBytes = getMessage1CommandBytes(itho->command);
-	packet->data[9] = packet->data[9] | commandBytes[0];	//only last bit is set
-	packet->data[10] = commandBytes[1];
-	packet->data[11] = commandBytes[2];
-	packet->data[12] = commandBytes[3];
-	packet->data[13] = commandBytes[4];
-	packet->data[14] = commandBytes[5];
-	packet->data[15] = commandBytes[6];
-
-	//fixed
-	packet->data[16] = 170;
-	packet->data[17] = 171;
-
-	//previous command
-	packet->data[18] = getMessage1Byte18(itho->previous);
 }
 
 void IthoCC1101::createMessageCommand(IthoPacket *itho, CC1101Packet *packet)
 {
-	packet->length = 50;
 
-	//fixed
-	packet->data[0] = 170;
-	packet->data[1] = 170;
-	packet->data[2] = 170;
-	packet->data[3] = 170;
-	packet->data[4] = 170;
-	packet->data[5] = 170;
-	packet->data[6] = 170;
-	packet->data[7] = 171;
-	packet->data[8] = 254;
-	packet->data[9] = 0;
-	packet->data[10] = 179;
-	packet->data[11] = 42;
-	packet->data[12] = 171;
-	packet->data[13] = 42;
-	packet->data[14] = 149;
-	packet->data[15] = 154;
+  //set start message structure
+  createMessageStart(itho, packet);
 
-	//device id message 2
-	packet->data[16] = itho->deviceId2[0];
-	packet->data[17] = itho->deviceId2[1];
-	packet->data[18] = itho->deviceId2[2];
-	packet->data[19] = itho->deviceId2[3];
-	packet->data[20] = itho->deviceId2[4];
-	packet->data[21] = itho->deviceId2[5];
-	packet->data[22] = itho->deviceId2[6];
-	packet->data[23] = itho->deviceId2[7];
+  //set deviceType? (or messageType?), not sure what this is
+  itho->dataDecoded[0] = itho->deviceType;
 
-	//counter bytes
-	packet->data[24] = calculateMessage2Byte24(itho->counter);
-	packet->data[25] = calculateMessage2Byte25(itho->counter);
-	packet->data[26] = calculateMessage2Byte26(itho->counter);
+  //set deviceID
+  itho->dataDecoded[1] = itho->deviceId[0];
+  itho->dataDecoded[2] = itho->deviceId[1];
+  itho->dataDecoded[3] = itho->deviceId[2];
 
-	//command
-	uint8_t *commandBytes = getMessage2CommandBytes(itho->command);
-	packet->data[26] = packet->data[26] | commandBytes[0];
-	packet->data[27] = commandBytes[1];
-	packet->data[28] = commandBytes[2];
-	packet->data[29] = commandBytes[3];
-	packet->data[30] = commandBytes[4];
-	packet->data[31] = commandBytes[5];
-	packet->data[32] = commandBytes[6];
-	packet->data[33] = commandBytes[7];
-	packet->data[34] = commandBytes[8];
-	packet->data[35] = commandBytes[9];
-	packet->data[36] = commandBytes[10];
-	packet->data[37] = commandBytes[11];
-	packet->data[38] = commandBytes[12];
-	packet->data[39] = commandBytes[13];
-	packet->data[40] = commandBytes[14];
+  //set counter1
+  itho->dataDecoded[4] = itho->counter;
 
-	//counter bytes
-	packet->data[41] = calculateMessage2Byte41(itho->counter, itho->command);
-	packet->data[42] = calculateMessage2Byte42(itho->counter, itho->command);
-	packet->data[43] = calculateMessage2Byte43(itho->counter, itho->command);
+  //set command bytes on dataDecoded[5 - 10]
+  uint8_t *commandBytes = getMessageCommandBytes(itho->command);
+  for (uint8_t i = 0; i < 6; i++) {
+    itho->dataDecoded[i + 5] = commandBytes[i];
+  }
 
-	//fixed
-	packet->data[44] = 172;
-	packet->data[45] = 170;
-	packet->data[46] = 170;
-	packet->data[47] = 170;
-	packet->data[48] = 170;
-	packet->data[49] = 170;
+  //set counter2
+  itho->dataDecoded[11] = getCounter2(itho, 11);
+
+  itho->length = 12;
+
+  packet->length = messageEncode(itho, packet);
+  packet->length += 1;
+
+  //set end byte
+  packet->data[packet->length] = 172;
+  packet->length += 1;
+
+  //set end 'noise'
+  for (uint8_t i = packet->length; i < packet->length + 7; i++) {
+    packet->data[i] = 170;
+  }
+  packet->length += 7;
+
 }
 
 void IthoCC1101::createMessageJoin(IthoPacket *itho, CC1101Packet *packet)
 {
-	//message3 is an extension on message2
-	createMessageCommand(itho, packet);
 
-	packet->length = 72;
+  //set start message structure
+  createMessageStart(itho, packet);
 
-	//device id
-	packet->data[41] = itho->deviceId2[0];
-	packet->data[42] = itho->deviceId2[1];
-	packet->data[43] = itho->deviceId2[2];
-	packet->data[44] = itho->deviceId2[3];
-	packet->data[45] = itho->deviceId2[4];
-	packet->data[46] = itho->deviceId2[5];
-	packet->data[47] = itho->deviceId2[6];
-	packet->data[48] = itho->deviceId2[7];
+  //set deviceType? (or messageType?)
+  itho->dataDecoded[0] = itho->deviceType;
 
-	//command join
-	packet->data[49] = 85;
+  //set deviceID
+  itho->dataDecoded[1] = itho->deviceId[0];
+  itho->dataDecoded[2] = itho->deviceId[1];
+  itho->dataDecoded[3] = itho->deviceId[2];
 
-	//fixed
-	packet->data[50] = 165;
-	packet->data[51] = 105;
-	packet->data[52] = 89;
-	packet->data[53] = 86;
-	packet->data[54] = 106;
-	packet->data[55] = 149;
+  //set counter1
+  itho->dataDecoded[4] = itho->counter;
 
-	//device id
-	packet->data[56] = itho->deviceId2[0];
-	packet->data[57] = itho->deviceId2[1];
-	packet->data[58] = itho->deviceId2[2];
-	packet->data[59] = itho->deviceId2[3];
-	packet->data[60] = itho->deviceId2[4];
-	packet->data[61] = itho->deviceId2[5];
-	packet->data[62] = itho->deviceId2[6];
-	packet->data[63] = itho->deviceId2[7];
+  //set command bytes on dataDecoded[5 - ?]
+  uint8_t *commandBytes = getMessageCommandBytes(itho->command);
+  for (uint8_t i = 0; i < 6; i++) {
+    itho->dataDecoded[i + 5] = commandBytes[i];
+  }
 
-	//counter bytes
-	packet->data[64] = calculateMessage2Byte64(itho->counter);
-	packet->data[65] = calculateMessage2Byte65(itho->counter);
-	packet->data[66] = calculateMessage2Byte66(itho->counter);
+  //set deviceID
+  itho->dataDecoded[11] = itho->deviceId[0];
+  itho->dataDecoded[12] = itho->deviceId[1];
+  itho->dataDecoded[13] = itho->deviceId[2];
 
-	//fixed
-	packet->data[67] = 202;
-	packet->data[68] = 170;
-	packet->data[69] = 170;
-	packet->data[70] = 170;
-	packet->data[71] = 170;
+  itho->dataDecoded[14] = 1;
+  itho->dataDecoded[15] = 16;
+  itho->dataDecoded[16] = 224;
+
+  //set deviceID
+  itho->dataDecoded[17] = itho->deviceId[0];
+  itho->dataDecoded[18] = itho->deviceId[1];
+  itho->dataDecoded[19] = itho->deviceId[2];
+
+  //set counter2
+  itho->dataDecoded[20] = getCounter2(itho, 20);
+
+  itho->length = 21;
+
+  packet->length = messageEncode(itho, packet);
+  packet->length += 1;
+
+  //set end byte
+  packet->data[packet->length] = 202;
+  packet->length += 1;
+
+  //set end 'noise'
+  for (uint8_t i = packet->length; i < packet->length + 7; i++) {
+    packet->data[i] = 170;
+  }
+  packet->length += 7;
+
 }
 
 void IthoCC1101::createMessageLeave(IthoPacket *itho, CC1101Packet *packet)
 {
-	//message3 is an extension on message2
-	createMessageCommand(itho, packet);
 
-	packet->length = 57;
+  //set start message structure
+  createMessageStart(itho, packet);
 
-	//device id
-	packet->data[41] = itho->deviceId2[0];
-	packet->data[42] = itho->deviceId2[1];
-	packet->data[43] = itho->deviceId2[2];
-	packet->data[44] = itho->deviceId2[3];
-	packet->data[45] = itho->deviceId2[4];
-	packet->data[46] = itho->deviceId2[5];
-	packet->data[47] = itho->deviceId2[6];
-	packet->data[48] = itho->deviceId2[7];
+  //set deviceType? (or messageType?)
+  itho->dataDecoded[0] = itho->deviceType;
 
-	//counter bytes
-	packet->data[49] = calculateMessage2Byte49(itho->counter);
-	packet->data[50] = calculateMessage2Byte50(itho->counter);
-	packet->data[51] = calculateMessage2Byte51(itho->counter);
+  //set deviceID
+  itho->dataDecoded[1] = itho->deviceId[0];
+  itho->dataDecoded[2] = itho->deviceId[1];
+  itho->dataDecoded[3] = itho->deviceId[2];
 
-	//fixed
-	packet->data[52] = 202;
-	packet->data[53] = 170;
-	packet->data[54] = 170;
-	packet->data[55] = 170;
-	packet->data[56] = 170;
+  //set counter1
+  itho->dataDecoded[4] = itho->counter;
+
+  //set command bytes on dataDecoded[5 - 10]
+  uint8_t *commandBytes = getMessageCommandBytes(itho->command);
+  for (uint8_t i = 0; i < 6; i++) {
+    itho->dataDecoded[i + 5] = commandBytes[i];
+  }
+
+  //set deviceID
+  itho->dataDecoded[11] = itho->deviceId[0];
+  itho->dataDecoded[12] = itho->deviceId[1];
+  itho->dataDecoded[13] = itho->deviceId[2];
+
+  //set counter2
+  itho->dataDecoded[14] = getCounter2(itho, 14);
+
+  itho->length = 15;
+
+  packet->length = messageEncode(itho, packet);
+  packet->length += 1;
+
+  //set end byte
+  packet->data[packet->length] = 202;
+  packet->length += 1;
+
+  //set end 'noise'
+  for (uint8_t i = packet->length; i < packet->length + 7; i++) {
+    packet->data[i] = 170;
+  }
+  packet->length += 7;
+
 }
 
-//calculate 0-255 number out of 3 counter bytes
-uint8_t IthoCC1101::calculateMessageCounter(uint8_t byte24, uint8_t byte25, uint8_t byte26)
+uint8_t* IthoCC1101::getMessageCommandBytes(IthoCommand command)
 {
-	uint8_t result;
-
-	uint8_t a = getCounterIndex(&counterBytes24a[0],2,byte24 & 0b00000011);	//last 2 bits only
-	uint8_t b = getCounterIndex(&counterBytes24b[0],8,byte24 & 0b11111100);	//first 6 bits
-	uint8_t c = getCounterIndex(&counterBytes25[0],8,byte25);
-	uint8_t d = getCounterIndex(&counterBytes26[0],2,byte26);
-
-	result = (a * 128) + (b * 16) + (d * 8) + c;
-
-	return result;
-}
-
-IthoCommand IthoCC1101::getMessage1PreviousCommand(uint8_t byte18)
-{
-	switch (byte18)
-	{
-		case 77:
-			return IthoJoin;
-
-		case 82:
-			return IthoLeave;
-
-//		case 85:
-		default:
-			return IthoLow;
-	}
-}
-
-uint8_t IthoCC1101::getMessage1Byte18(IthoCommand command)
-{
-	switch (command)
-	{
-		case IthoJoin:
-			return 77;
-
-		case IthoLeave:
-			return 82;
-
-		default:
-			return 85;
-	}
-}
-
-uint8_t IthoCC1101::calculateMessage2Byte24(uint8_t counter)
-{
-	return counterBytes24a[(counter / 128)] | counterBytes24b[(counter % 128) / 16];
-}
-
-uint8_t IthoCC1101::calculateMessage2Byte25(uint8_t counter)
-{
-	return counterBytes25[(counter % 16) % 8];
-}
-
-uint8_t IthoCC1101::calculateMessage2Byte26(uint8_t counter)
-{
-	return counterBytes26[(counter % 16) / 8];
-}
-
-uint8_t IthoCC1101::calculateMessage2Byte41(uint8_t counter, IthoCommand command)
-{
-	int var = 0;
-	uint8_t hi = 0;
-
-	switch (command)
-	{
-		case IthoTimer1:
-		case IthoTimer3:
-			hi = 160;
-			var = 48 - command;
-			if (counter < var) counter = 64 - counter;
-			break;
-
-		case IthoJoin:
-			hi = 96;
-			counter = 0;
-			break;
-
-		case IthoLeave:
-			hi = 160;
-			counter = 0;
-			break;
-
-		default:
-			hi = 96;
-			var = 48 - command;
-			if (counter < var) counter = 74 - counter;
-			break;
-	}
-
-	return (hi | counterBytes41[((counter - var) % 64) / 16]);
-}
-
-uint8_t IthoCC1101::calculateMessage2Byte42(uint8_t counter, IthoCommand command)
-{
-	uint8_t result;
-
-	if (command == IthoJoin || command == IthoLeave)
-	{
-		counter = 1;
-	}
-	else
-	{
-		counter += command;
-	}
-
-	result = counterBytes42[counter / 64];
-
-	if (counter % 2 == 1) result -= 1;
-
-	return result;
-}
-
-uint8_t IthoCC1101::calculateMessage2Byte43(uint8_t counter, IthoCommand command)
-{
-	switch (command)
-	{
-		case IthoFull:
-			counter += 3;
-			if (counter % 2 == 0) counter -= 1;
-			break;
-
-		case IthoHigh:
-			counter += 2;
-			if (counter % 2 == 0) counter -= 1;
-			break;
-
-		case IthoUnknown:
-		case IthoMedium:
-			break;
-
-		case IthoLow:
-		case IthoTimer2:
-			if (counter % 2 == 0) counter -= 1;
-			break;
-
-		case IthoStandby:
-			counter -= 1;
-			if (counter % 2 == 0) counter -= 1;
-			break;
-
-		case IthoTimer1:
-			counter += 6;
-			if (counter % 2 == 0) counter -= 1;
-			break;
-
-		case IthoTimer3:
-			counter += 10;
-			if (counter % 2 == 0) counter -= 1;
-			break;
-
-		case IthoJoin:
-		case IthoLeave:
-			counter = 0;
-			break;
-
-		case DucoHigh:
-			counter += 10;
-			if (counter % 2 != 0) counter -= 1;
-			break;
-
-		case DucoMedium:
-			counter += 9;
-			if (counter % 2 != 0) counter -= 1;
-			break;
-
-		case DucoLow:
-			counter += 8;
-			break;
-
-		case DucoStandby:
-			counter += 8;
-			if (counter % 2 == 0) counter -= 1;
-			break;
-
-		default:
-			counter = 0;
-			break;
-	}
-	return counterBytes43[(counter % 16) / 2];
-}
-
-uint8_t IthoCC1101::calculateMessage2Byte49(uint8_t counter)
-{
-	counter += 47;
-	return counterBytes64[(counter / 16)];
-}
-
-uint8_t IthoCC1101::calculateMessage2Byte50(uint8_t counter)
-{
-	counter -= 4;
-	return counterBytes65[counter % 8];
-}
-
-uint8_t IthoCC1101::calculateMessage2Byte51(uint8_t counter)
-{
-	counter -= 1;
-	return counterBytes66[(counter % 16) / 8];
-}
-
-uint8_t IthoCC1101::calculateMessage2Byte64(uint8_t counter)
-{
-	counter += 3;
-	return counterBytes64[counter / 16];
-}
-
-uint8_t IthoCC1101::calculateMessage2Byte65(uint8_t counter)
-{
-	return counterBytes65[counter % 8];
-}
-
-uint8_t IthoCC1101::calculateMessage2Byte66(uint8_t counter)
-{
-	counter -= 13;
-	return counterBytes66[(counter % 16) / 8];
+  switch (command)
+  {
+    case IthoStandby:
+      return (uint8_t*)&ithoMessageStandByCommandBytes[0];
+    case IthoHigh:
+      return (uint8_t*)&ithoMessageHighCommandBytes[0];
+    case IthoFull:
+      return (uint8_t*)&ithoMessageFullCommandBytes[0];
+    case IthoMedium:
+      return (uint8_t*)&ithoMessageMediumCommandBytes[0];
+    case IthoLow:
+      return (uint8_t*)&ithoMessageLowCommandBytes[0];
+    case IthoTimer1:
+      return (uint8_t*)&ithoMessageTimer1CommandBytes[0];
+    case IthoTimer2:
+      return (uint8_t*)&ithoMessageTimer2CommandBytes[0];
+    case IthoTimer3:
+      return (uint8_t*)&ithoMessageTimer3CommandBytes[0];
+    case IthoJoin:
+      return (uint8_t*)&ithoMessageJoinCommandBytes[0];
+    case IthoLeave:
+      return (uint8_t*)&ithoMessageLeaveCommandBytes[0];
+    default:
+      return (uint8_t*)&ithoMessageLowCommandBytes[0];
+  }
 }
 
 /*
-uint8_t* IthoCC1101::getMessage1CommandBytes(IthoCommand command)
-{
-	switch (command)
-	{
-		case IthoFull:
-		case IthoHigh:
-			return (uint8_t*)&ithoMessage1HighCommandBytes[0];
-		case IthoMedium:
-			return (uint8_t*)&ithoMessage1MediumCommandBytes[0];
-		case IthoLow:
-			return (uint8_t*)&ithoMessage1LowCommandBytes[0];
-		case IthoTimer1:
-			return (uint8_t*)&ithoMessage1Timer1CommandBytes[0];
-		case IthoTimer2:
-			return (uint8_t*)&ithoMessage1Timer2CommandBytes[0];
-		case IthoTimer3:
-			return (uint8_t*)&ithoMessage1Timer3CommandBytes[0];
-		case IthoJoin:
-			return (uint8_t*)&ithoMessage1JoinCommandBytes[0];
-		case IthoLeave:
-			return (uint8_t*)&ithoMessage1LeaveCommandBytes[0];
-		default:
-			return (uint8_t*)&ithoMessage1LowCommandBytes[0];
-	}
-}
+   Counter2 is the decimal sum of all bytes in decoded form from
+   deviceType up to the last byte before counter2 subtracted
+   from zero.
 */
+uint8_t IthoCC1101::getCounter2(IthoPacket *itho, uint8_t len) {
 
-uint8_t* IthoCC1101::getMessage2CommandBytes(IthoCommand command)
-{
-	switch (command)
-	{
-		case IthoFull:
-			return (uint8_t*)&ithoMessage2PowerCommandBytes[0];
-		case IthoStandby:
-			return (uint8_t*)&ithoMessage2StandByCommandBytes[0];
-		case IthoHigh:
-			return (uint8_t*)&ithoMessage2HighCommandBytes[0];
-		case IthoMedium:
-			return (uint8_t*)&ithoMessage2MediumCommandBytes[0];
-		case IthoLow:
-			return (uint8_t*)&ithoMessage2LowCommandBytes[0];
-		case IthoTimer1:
-			return (uint8_t*)&ithoMessage2Timer1CommandBytes[0];
-		case IthoTimer2:
-			return (uint8_t*)&ithoMessage2Timer2CommandBytes[0];
-		case IthoTimer3:
-			return (uint8_t*)&ithoMessage2Timer3CommandBytes[0];
-		case IthoJoin:
-			return (uint8_t*)&ithoMessage2JoinCommandBytes[0];
-		case IthoLeave:
-			return (uint8_t*)&ithoMessage2LeaveCommandBytes[0];
-		default:
-			return (uint8_t*)&ithoMessage2LowCommandBytes[0];
-	}
+  uint8_t val = 0;
+
+  for (uint8_t i = 0; i < len; i++) {
+    val += itho->dataDecoded[i];
+  }
+
+  return 0 - val;
 }
 
-//lookup value in array
-uint8_t IthoCC1101::getCounterIndex(const uint8_t *arr, uint8_t length, uint8_t value)
-{
-	for (uint8_t i=0; i<length; i++)
-		if (arr[i] == value)
-			return i;
+uint8_t IthoCC1101::messageEncode(IthoPacket *itho, CC1101Packet *packet) {
 
-	//-1 should never be returned!
-	return -1;
+  uint8_t lenOutbuf = 0;
+
+  if ((itho->length * 20) % 8 == 0) { //inData len fits niecly in out buffer length
+    lenOutbuf = itho->length * 2.5;
+  }
+  else { //is this an issue? inData last byte does not fill out buffer length, add 1 out byte extra, padding is done after encode
+    lenOutbuf = (uint8_t)(itho->length * 2.5) + 0.5;
+  }
+
+  uint8_t out_bytecounter = 14;   //index of Outbuf, start at offset 14, first part of the message is set manually
+  uint8_t out_bitcounter = 0;     //bit position of current outbuf byte
+  uint8_t out_patterncounter = 0; //bit counter to add 1 0 bit pattern after every 8 bits
+  uint8_t bitSelect = 4;          //bit position of the inData byte (4 - 7, 0 - 3)
+  uint8_t out_shift = 7;          //bit shift inData bit in position of outbuf byte
+
+  //we need to zero the out buffer first cause we are using bitshifts
+  for (int i = out_bytecounter; i < sizeof(packet->data) / sizeof(packet->data[0]); i++) {
+    packet->data[i] = 0;
+  }
+
+  //Serial.println();
+  for (uint8_t dataByte = 0; dataByte < itho->length; dataByte++) {
+    for (uint8_t dataBit = 0; dataBit < 8; dataBit++) {                                     //process a full dataByte at a time resulting in 20 output bits (2.5 bytes) with the pattern 7x6x5x4x 10 3x2x1x0x 10 7x6x5x4x 10 3x2x1x0x 10 etc
+      if (out_bitcounter == 8) {                                                            //check if new byte is needed
+        out_bytecounter++;
+        out_bitcounter = 0;
+      }
+
+      if (out_patterncounter == 8) {                                                        //check if we have to start with a 1 0 pattern
+        out_patterncounter = 0;
+        packet->data[out_bytecounter] = packet->data[out_bytecounter] | 1 << out_shift;
+        out_shift--;
+        out_bitcounter++;
+        packet->data[out_bytecounter] = packet->data[out_bytecounter] | 0 << out_shift;
+        if (out_shift == 0) out_shift = 8;
+        out_shift--;
+        out_bitcounter++;
+      }
+
+      if (out_bitcounter == 8) {                                                            //check if new byte is needed
+        out_bytecounter++;
+        out_bitcounter = 0;
+      }
+
+      //set the even bit
+      uint8_t bit = (itho->dataDecoded[dataByte] & (1 << bitSelect)) >> bitSelect;          //select bit and shift to bit pos 0
+      bitSelect++;
+      if (bitSelect == 8) bitSelect = 0;
+
+      packet->data[out_bytecounter] = packet->data[out_bytecounter] | bit << out_shift;     //shift bit in corect pos of current outbuf byte
+      out_shift--;
+      out_bitcounter++;
+      out_patterncounter++;
+
+      //set the odd bit (inverse of even bit)
+      bit = ~bit & 0b00000001;
+      packet->data[out_bytecounter] = packet->data[out_bytecounter] | bit << out_shift;
+      if (out_shift == 0) out_shift = 8;
+      out_shift--;
+      out_bitcounter++;
+      out_patterncounter++;
+
+    }
+
+  }
+  if (out_bitcounter < 8) {                                                                   //add closing 1 0 pattern to fill last packet->data byte and ensure DC balance in the message
+    for (uint8_t i = out_bitcounter; i < 8; i += 2) {
+      packet->data[out_bytecounter] = packet->data[out_bytecounter] | 1 << out_shift;
+      out_shift--;
+      packet->data[out_bytecounter] = packet->data[out_bytecounter] | 0 << out_shift;
+      if (out_shift == 0) out_shift = 8;
+      out_shift--;
+    }
+  }
+
+  return out_bytecounter;
+}
+
+
+void IthoCC1101::messageDecode(CC1101Packet *packet, IthoPacket *itho) {
+
+  itho->length = 0;
+  int lenInbuf = packet->length;
+
+  lenInbuf -= STARTBYTE; //correct for sync byte pos
+
+  while (lenInbuf >= 5) {
+    lenInbuf -= 5;
+    itho->length += 2;
+  }
+  if (lenInbuf >= 3) {
+    itho->length++;
+  }
+
+  for (int i = 0; i < sizeof(itho->dataDecoded) / sizeof(itho->dataDecoded[0]); i++) {
+    itho->dataDecoded[i] = 0;
+  }
+  for (int i = 0; i < sizeof(itho->dataDecodedChk) / sizeof(itho->dataDecodedChk[0]); i++) {
+    itho->dataDecodedChk[i] = 0;
+  }
+
+  uint8_t out_i = 0;                                  //byte index
+  uint8_t out_j = 4;                                  //bit index
+  uint8_t out_i_chk = 0;                              //byte index
+  uint8_t out_j_chk = 4;                              //bit index
+  uint8_t in_bitcounter = 0;                          //process per 10 input bits
+
+  for (int i = STARTBYTE; i < packet->length; i++) {
+
+    for (int j = 7; j > -1; j--) {
+      if (in_bitcounter == 0 || in_bitcounter == 2 || in_bitcounter == 4 || in_bitcounter == 6) { //select input bits for output
+        uint8_t x = packet->data[i];   //select input byte
+        x = x >> j;             //select input bit
+        x = x & 0b00000001;
+        x = x << out_j;         //set value for output bit
+        itho->dataDecoded[out_i] = itho->dataDecoded[out_i] | x;
+        out_j += 1;             //next output bit
+        if (out_j > 7) out_j = 0;
+        if (out_j == 4) out_i += 1;
+      }
+      if (in_bitcounter == 1 || in_bitcounter == 3 || in_bitcounter == 5 || in_bitcounter == 7) { //select input bits for check output
+        uint8_t x = packet->data[i];   //select input byte
+        x = x >> j;             //select input bit
+        x = x & 0b00000001;
+        x = x << out_j_chk;         //set value for output bit
+        itho->dataDecodedChk[out_i_chk] = itho->dataDecodedChk[out_i_chk] | x;
+        out_j_chk += 1;             //next output bit
+        if (out_j_chk > 7) out_j_chk = 0;
+        if (out_j_chk == 4) {
+          itho->dataDecodedChk[out_i_chk] = ~itho->dataDecodedChk[out_i_chk]; //inverse bits
+          out_i_chk += 1;
+        }
+      }
+      in_bitcounter += 1;     //continue cyling in groups of 10 bits
+      if (in_bitcounter > 9) in_bitcounter = 0;
+    }
+  }
 }
 
 uint8_t IthoCC1101::ReadRSSI()
@@ -978,34 +785,65 @@ uint8_t IthoCC1101::ReadRSSI()
     value = rssi / 2;
     value += 74;
   }
-  return(value);
+  return (value);
 }
 
 bool IthoCC1101::checkID(const uint8_t *id)
 {
-	for (uint8_t i=0; i<8;i++)
-		if (id[i] != inIthoPacket.deviceId2[i])
-			return false;
-	return true;
+  for (uint8_t i = 0; i < 3; i++)
+    if (id[i] != inIthoPacket.deviceId[i])
+      return false;
+  return true;
 }
 
 String IthoCC1101::getLastIDstr(bool ashex) {
-	String str;
-	str.reserve(24);
-	for (uint8_t i=0; i<8;i++) {
-		if (ashex) str += String(inIthoPacket.deviceId2[i], HEX);
-		else str += String(inIthoPacket.deviceId2[i]);
-		if (i<7) str += ":";
-	}
-	return str;
+  String str;
+  for (uint8_t i = 0; i < 3; i++) {
+    if (ashex) str += String(inIthoPacket.deviceId[i], HEX);
+    else str += String(inIthoPacket.deviceId[i]);
+    if (i < 2) str += ",";
+  }
+  return str;
 }
-/* Function currently not in use
-String IthoCC1101::getLastMessage2str(bool ashex) {
-    String str = "Length="+ String(inMessage2.length) + ".";
-    for (uint8_t i=0; i<inMessage2.length;i++) {
-        if (ashex) str += String(inMessage2.data[i], HEX);
-        else str += String(inMessage2.data[i]);
-		if (i<inMessage2.length-1) str += ":";
+
+int * IthoCC1101::getLastID() {
+  static int id[3];
+  for (uint8_t i = 0; i < 3; i++) {
+    id[i] = inIthoPacket.deviceId[i];
+  }
+  return id;
+}
+
+String IthoCC1101::getLastMessagestr(bool ashex) {
+  String str = "Length=" + String(inMessage.length) + ".";
+  for (uint8_t i = 0; i < inMessage.length; i++) {
+    if (ashex) str += String(inMessage.data[i], HEX);
+    else str += String(inMessage.data[i]);
+    if (i < inMessage.length - 1) str += ":";
+  }
+  return str;
+}
+
+String IthoCC1101::LastMessageDecoded() {
+
+  String str;
+  if (inIthoPacket.length > 11) {
+    str += "Device type?: " + String(inIthoPacket.deviceType);
+    str += " - CMD: ";
+    for (int i = 4; i < inIthoPacket.length; i++) {
+      str += String(inIthoPacket.dataDecoded[i]);
+      if (i < inIthoPacket.length - 1) str += ",";
     }
-    return str;
-}*/
+
+  }
+  else {
+    for (uint8_t i = 0; i < inIthoPacket.length; i++) {
+      str += String(inIthoPacket.dataDecoded[i]);
+      if (i < inIthoPacket.length - 1) str += ",";
+    }
+
+  }
+  str += "\n";
+  return str;
+
+}

--- a/libraries _PLUGIN145 ITHO FAN/Itho/IthoCC1101.h
+++ b/libraries _PLUGIN145 ITHO FAN/Itho/IthoCC1101.h
@@ -1,5 +1,5 @@
 /*
- * Author: Klusjesman, modified bij supersjimmie for Arduino/ESP8266
+ * Author: Klusjesman, supersjimmie, modified and reworked by arjenhiemstra 
  */
 
 #ifndef __ITHOCC1101_H__
@@ -14,171 +14,103 @@
 const uint8_t ithoPaTableSend[8] = {0x6F, 0x26, 0x2E, 0x8C, 0x87, 0xCD, 0xC7, 0xC0};
 const uint8_t ithoPaTableReceive[8] = {0x6F, 0x26, 0x2E, 0x7F, 0x8A, 0x84, 0xCA, 0xC4};
 
-//rft message 1 commands
-const uint8_t ithoMessage1HighCommandBytes[] = {1,84,213,85,50,203,52};
-const uint8_t ithoMessage1MediumCommandBytes[] = {1,84,213,85,74,213,52};
-const uint8_t ithoMessage1LowCommandBytes[] = {1,84,213,85,83,83,84};
-const uint8_t ithoMessage1Timer1CommandBytes[] = {1,83,83,84,204,202,180};
-const uint8_t ithoMessage1Timer2CommandBytes[] = {1,83,83,83,53,52,180};
-const uint8_t ithoMessage1Timer3CommandBytes[] = {1,83,83,82,173,82,180};
-const uint8_t ithoMessage1JoinCommandBytes[] = {0,170,171,85,84,202,180};
-const uint8_t ithoMessage1LeaveCommandBytes[] = {0,170,173,85,83,43,84};
+//message command bytes
+const uint8_t ithoMessageRVHighCommandBytes[] =   {49,224,4,0,0,200};
+const uint8_t ithoMessageHighCommandBytes[] =     {34,241,3,0,4,4};
+const uint8_t ithoMessageFullCommandBytes[] =     {34,241,3,0,4,4};
+const uint8_t ithoMessageMediumCommandBytes[] =   {34,241,3,0,3,4};
+const uint8_t ithoMessageRVMediumCommandBytes[] = {34,241,3,0,3,7};
+const uint8_t ithoMessageLowCommandBytes[] =      {34,241,3,0,2,4};
+const uint8_t ithoMessageRVLowCommandBytes[] =    {49,224,4,0,0,1};
+const uint8_t ithoMessageRVAutoCommandBytes[] =   {34,241,3,0,5,7};
+const uint8_t ithoMessageStandByCommandBytes[] =  {0,0,0,0,0,0};         //unkown, tbd
+const uint8_t ithoMessageTimer1CommandBytes[] =   {34,243,3,0,0,10};     //10 minutes full speed
+const uint8_t ithoMessageTimer2CommandBytes[] =   {34,243,3,0,0,20};     //20 minutes full speed
+const uint8_t ithoMessageTimer3CommandBytes[] =   {34,243,3,0,0,30};     //30 minutes full speed
+const uint8_t ithoMessageJoinCommandBytes[] =     {31,201,12,0,34,241};
+const uint8_t ithoMessageJoin2CommandBytes[] =    {31,201,12,99,34,248};  //join command of RFT AUTO Co2 remote
+const uint8_t ithoMessageRVJoinCommandBytes[] =   {31,201,24,0,49,224};  //join command of RFT-RV
+const uint8_t ithoMessageLeaveCommandBytes[] =    {31,201,6,0,31,201};
+//itho rft-rv
+//unknown, high
+//148,216,43,49,224,4,0,0,200,0,3,127,244,78,11,155,154,225,11,96,138
+//148,216,43,49,224,4,0,0,200,0,3,127,51,80,47,233,94,6,189,114,73
 
-//duco message1 commands
-const uint8_t ducoMessage1HighCommandBytes[] = {1,84,213,85,51,45,52};
-const uint8_t ducoMessage1MediumCommandBytes[] = {1,84,213,85,75,51,52};
-const uint8_t ducoMessage1LowCommandBytes[] = {1,84,213,85,82,181,84};
-const uint8_t ducoMessage1StandByCommandBytes[] = {1,85,53,84,205,85,52};
-const uint8_t ducoMessage1JoinCommandBytes[] = {0,170,171,85,85,44,180};
-const uint8_t ducoMessage1LeaveCommandBytes[] = {0,170,173,85,82,205,84};
+//low
+//148,216,43,49,224,4,0,0,1,0,202,127,242,212,160,123,15,64,7,129,33
+//148,216,43,34,241,3,0,4,4,194,127,255,189,90,107,88,72,115,49,192,105
 
-//message 2 commands
-const uint8_t ithoMessage2PowerCommandBytes[] = {6,89,150,170,165,101,90,150,85,149,101,90,102,85,150};
-const uint8_t ithoMessage2HighCommandBytes[] = {6,89,150,170,165,101,90,150,85,149,101,89,102,85,150};
-const uint8_t ithoMessage2MediumCommandBytes[] = {6,89,150,170,165,101,90,150,85,149,101,90,150,85,150};
-const uint8_t ithoMessage2LowCommandBytes[] = {6,89,150,170,165,101,90,150,85,149,101,89,150,85,150};
-const uint8_t ithoMessage2StandByCommandBytes[] = {6,89,150,170,165,101,90,150,85,149,101,90,86,85,150};
-const uint8_t ithoMessage2Timer1CommandBytes[] = {6,89,150,170,169,101,90,150,85,149,101,89,86,85,153};		//10 minutes full speed
-const uint8_t ithoMessage2Timer2CommandBytes[] = {6,89,150,170,169,101,90,150,85,149,101,89,86,149,150};	//20 minutes full speed
-const uint8_t ithoMessage2Timer3CommandBytes[] = {6,89,150,170,169,101,90,150,85,149,101,89,86,149,154};	//30 minutes full speed
-const uint8_t ithoMessage2JoinCommandBytes[] = {9,90,170,90,165,165,89,106,85,149,102,89,150,170,165};
-const uint8_t ithoMessage2LeaveCommandBytes[] = {9,90,170,90,165,165,89,166,85,149,105,90,170,90,165};
-
-//message 2, counter
-const uint8_t counterBytes24a[] = {1,2};
-const uint8_t counterBytes24b[] = {84,148,100,164,88,152,104,168};
-const uint8_t counterBytes25[] = {149,165,153,169,150,166,154,170};
-const uint8_t counterBytes26[] = {96,160};
-const uint8_t counterBytes41[] = {5, 10, 6, 9};
-const uint8_t counterBytes42[] = {90, 170, 106, 154};
-const uint8_t counterBytes43[] = {154, 90, 166, 102, 150, 86, 170, 106};
-//join/leave
-const uint8_t counterBytes64[] = {154,90,166,102,150,86,169,105,153,89,165,101,149,85,170,106};
-const uint8_t counterBytes65[] = {150,169,153,165,149,170,154,166};
-const uint8_t counterBytes66[] = {170,106};
-
-
-//state machine
-enum IthoReceiveStates
-{
-	ExpectMessageStart,
-	ExpectNormalCommand,
-	ExpectJoinCommand,
-	ExpectLeaveCommand
-};
-
+//join
+//151,149,65,31,201,24,0,49,224,151,149,65,0,18,160,151,149,65,1,16,224
 
 
 class IthoCC1101 : protected CC1101
 {
-	private:
-		//receive
-		IthoReceiveStates receiveState;											//state machine receive
-		unsigned long lastMessage1Received;										//used for timeout detection
-		CC1101Packet inMessage1;												//temp storage message1
-		CC1101Packet inMessage2;												//temp storage message2
-		IthoPacket inIthoPacket;												//stores last received message data
+  private:
+    //receive
+    CC1101Packet inMessage;                       //temp storage message2
+    IthoPacket inIthoPacket;                        //stores last received message data
+    
+    //send
+    IthoPacket outIthoPacket;                       //stores state of "remote"
 
-		//send
-		IthoPacket outIthoPacket;												//stores state of "remote"
+    //settings
+    uint8_t sendTries;                            //number of times a command is send at one button press
+    
+  //functions
+  public:
+    IthoCC1101(uint8_t counter = 0, uint8_t sendTries = 3);   //set initial counter value
+    ~IthoCC1101();
+    
+    //init
+    void init() { CC1101::init(); initReceive(); }                    //init,reset CC1101
+    void initReceive();
+    uint8_t getLastCounter() { return outIthoPacket.counter; }        //counter is increased before sending a command
+    void setSendTries(uint8_t sendTries) { this->sendTries = sendTries; }
+    void setDeviceID(uint8_t byte0, uint8_t byte1, uint8_t byte2) { this->outIthoPacket.deviceId[0] = byte0; this->outIthoPacket.deviceId[1] = byte1; this->outIthoPacket.deviceId[2] = byte2;}
+    
+    //receive
+    bool checkForNewPacket();                       //check RX fifo for new data
+    IthoPacket getLastPacket() { return inIthoPacket; }           //retrieve last received/parsed packet from remote
+    IthoCommand getLastCommand() { return inIthoPacket.command; }           //retrieve last received/parsed command from remote
+    uint8_t getLastInCounter() { return inIthoPacket.counter; }           //retrieve last received/parsed command from remote
+    uint8_t ReadRSSI();
+    bool checkID(const uint8_t *id);
+    int * getLastID();
+    String getLastIDstr(bool ashex=true);
+    String getLastMessagestr(bool ashex=true);
+    String LastMessageDecoded();
+        
+    //send
+    void sendCommand(IthoCommand command);
+  protected:
+  private:
+    IthoCC1101( const IthoCC1101 &c);
+    IthoCC1101& operator=( const IthoCC1101 &c);
 
-		//settings
-		uint8_t sendTries;														//number of times a command is send at one button press
-
-		//SYNC1 byte
-		uint8_t remoteSync1 = 170;													//SYNC1 byte for reconfiguring remote decoding, default 170
-
-	//functions
-	public:
-		IthoCC1101(uint8_t counter = 0, uint8_t sendTries = 3);		//set initial counter value
-		~IthoCC1101();
-
-		//init
-		void init() { CC1101::init(); }											//init,reset CC1101
-		void initReceive();
-		uint8_t getLastCounter() { return outIthoPacket.counter; }				//counter is increased before sending a command
-		void setSendTries(uint8_t sendTries) { this->sendTries = sendTries; }
-
-		//- deviceid should be a setting as well? random gen function? TODO
-
-		//receive
-		bool checkForNewPacket();												//check RX fifo for new data
-		IthoPacket getLastPacket() { return inIthoPacket; }						//retrieve last received/parsed packet from remote
-		IthoCommand getLastCommand() { return inIthoPacket.command; }						//retrieve last received/parsed command from remote
-		uint8_t getLastInCounter() { return inIthoPacket.counter; }						//retrieve last received/parsed command from remote
-		uint8_t ReadRSSI();
-		bool checkID(const uint8_t *id);
-		String getLastIDstr(bool ashex=true);
-		String getLastMessage2str(bool ashex=true);
-
-		//send
-		void sendCommand(IthoCommand command);
-
-		//SYNC1 programming
-		void setSync1(uint8_t remoteSync1){ this->remoteSync1 = remoteSync1; }
-	protected:
-	private:
-		IthoCC1101( const IthoCC1101 &c);
-		IthoCC1101& operator=( const IthoCC1101 &c);
-
-		//init CC1101 for receiving
-		void initReceiveMessage1();
-		void initReceiveMessage2(IthoMessageType expectedMessageType);
-
-		//init CC1101 for sending
-		void initSendMessage1();
-		void initSendMessage2(IthoCommand command);
-		void finishTransfer();
-
-		//receive message validation
-		bool isValidMessageStart();
-		bool isValidMessageCommand();
-		bool isValidMessageJoin();
-		bool isValidMessageLeave();
-
-		//parse received message
-		void parseReceivedPackets();
-		void parseMessageStart();
-		void parseMessageCommand();
-		void parseMessageJoin();
-		void parseMessageLeave();
-
-		//send
-		void createMessageStart(IthoPacket *itho, CC1101Packet *packet);
-		void createMessageCommand(IthoPacket *itho, CC1101Packet *packet);
-		void createMessageJoin(IthoPacket *itho, CC1101Packet *packet);
-		void createMessageLeave(IthoPacket *itho, CC1101Packet *packet);
-		uint8_t* getMessage1CommandBytes(IthoCommand command);
-		uint8_t* getMessage2CommandBytes(IthoCommand command);
-
-		//counter bytes calculation (send)
-		uint8_t getMessage1Byte18(IthoCommand command);
-		IthoCommand getMessage1PreviousCommand(uint8_t byte18);
-		uint8_t calculateMessage2Byte24(uint8_t counter);
-		uint8_t calculateMessage2Byte25(uint8_t counter);
-		uint8_t calculateMessage2Byte26(uint8_t counter);
-		uint8_t calculateMessage2Byte41(uint8_t counter, IthoCommand command);
-		uint8_t calculateMessage2Byte42(uint8_t counter, IthoCommand command);
-		uint8_t calculateMessage2Byte43(uint8_t counter, IthoCommand command);
-		uint8_t calculateMessage2Byte49(uint8_t counter);
-		uint8_t calculateMessage2Byte50(uint8_t counter);
-		uint8_t calculateMessage2Byte51(uint8_t counter);
-		uint8_t calculateMessage2Byte64(uint8_t counter);
-		uint8_t calculateMessage2Byte65(uint8_t counter);
-		uint8_t calculateMessage2Byte66(uint8_t counter);
-
-		//counter calculation (receive)
-		uint8_t calculateMessageCounter(uint8_t byte24, uint8_t byte25, uint8_t byte26);
-
-		//general
-		uint8_t getCounterIndex(const uint8_t *arr, uint8_t length, uint8_t value);
-
-		//test
-		void testCreateMessage();
+    //init CC1101 for receiving
+    void initReceiveMessage();
+    
+    //init CC1101 for sending
+    void initSendMessage(uint8_t len);
+    void finishTransfer();    
+      
+    //parse received message
+    bool parseMessageCommand();
+    bool checkIthoCommand(IthoPacket *itho, const uint8_t commandBytes[]);
+    
+    //send
+    void createMessageStart(IthoPacket *itho, CC1101Packet *packet);
+    void createMessageCommand(IthoPacket *itho, CC1101Packet *packet);
+    void createMessageJoin(IthoPacket *itho, CC1101Packet *packet);
+    void createMessageLeave(IthoPacket *itho, CC1101Packet *packet);
+    uint8_t* getMessageCommandBytes(IthoCommand command);
+    uint8_t getCounter2(IthoPacket *itho, uint8_t len);
+    
+    uint8_t messageEncode(IthoPacket *itho, CC1101Packet *packet);
+    void messageDecode(CC1101Packet *packet, IthoPacket *itho);
+    
 
 }; //IthoCC1101
-
-
-extern volatile uint32_t data1[];
 
 #endif //__ITHOCC1101_H__

--- a/libraries _PLUGIN145 ITHO FAN/Itho/IthoPacket.h
+++ b/libraries _PLUGIN145 ITHO FAN/Itho/IthoPacket.h
@@ -1,55 +1,48 @@
 /*
- * Author: Klusjesman, modified bij supersjimmie for Arduino/ESP8266
+ * Author: Klusjesman, supersjimmie, modified and reworked by arjenhiemstra 
  */
 
 #ifndef ITHOPACKET_H_
 #define ITHOPACKET_H_
 
-
-enum IthoMessageType
- {
- 	ithomsg_unknown = 0,
- 	ithomsg_control = 1,
- 	ithomsg_join = 2,
- 	ithomsg_leave = 3
- };
-
- //do not change enum because they are used in calculations!
 enum IthoCommand
-{
-	IthoUnknown = 0,
-
-	IthoJoin = 4,
-	IthoLeave = 8,
-
-	IthoStandby = 34,
-	IthoLow = 35,
-	IthoMedium = 36,
-	IthoHigh = 37,
-	IthoFull = 38,
-
-	IthoTimer1 = 41,
-	IthoTimer2 = 51,
-	IthoTimer3 = 61,
-
-	//duco c system remote
-	DucoStandby = 251,
-	DucoLow = 252,
-	DucoMedium = 253,
-	DucoHigh = 254
+{    
+  IthoUnknown = 0,
+    
+  IthoJoin = 1,
+  IthoLeave = 2,
+        
+  IthoStandby = 3,
+  IthoLow = 4,
+  IthoMedium = 5,
+  IthoHigh = 6,
+  IthoFull = 7,
+  
+  IthoTimer1 = 8,
+  IthoTimer2 = 9,
+  IthoTimer3 = 10,
+  
+  //duco c system remote
+  DucoStandby = 11,
+  DucoLow = 12,
+  DucoMedium = 13,
+  DucoHigh = 14
 };
 
 
 class IthoPacket
 {
-	public:
-		uint8_t deviceId1[6];
-		uint8_t deviceId2[8];
-		IthoMessageType messageType;
-		IthoCommand command;
-		IthoCommand previous;
+  public:
+    IthoCommand command;
 
-		uint8_t counter;		//0-255, counter is increased on every remote button press
+    uint8_t dataDecoded[32];
+    uint8_t dataDecodedChk[32];
+    uint8_t length;
+    
+    uint8_t deviceType;
+    uint8_t deviceId[3];
+    
+    uint8_t counter;    //0-255, counter is increased on every remote button press
 };
 
 


### PR DESCRIPTION
Complete rework of Itho library by arjenhiemstra (https://github.com/arjenhiemstra/IthoEcoFanRFT), from his GitHub:
*  Library structure is preserved, should be a drop in replacement (apart from device id)
*  Decode incoming messages to direct usable decimals without further bit-shifting
*  DeviceID is now 3 bytes long and can be set during runtime
*  Counter2 is now the decimal sum of all bytes in decoded form from deviceType up to the last byte before counter2 subtracted from zero.
*  Encode outgoing messages in itho compatible format
*  Added ICACHE_RAM_ATTR to 'void ITHOcheck()' for ESP8266/ESP32 compatibility
*  Trigger on the falling edge and simplified ISR routine for more robust packet handling
*  Move SYNC word from 171,170 further down the message to 179,42,163,42 to filter out more non-itho messages in CC1101 hardware

Sten Vollebregt:
* Updated plugin to accommodate changes in new library
* Device ID of the ESP is now programmable in the plugin
* Removed SYNC1 setting as it is (likely) not required anymore

Tested on ESP8266 with the latest mega and found to be rock-stable.